### PR TITLE
Added single cell library prep option UDFs to project page

### DIFF
--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -36,7 +36,11 @@ Description: Details page for a single project
       <dt>Library Method</dt>				    <dd id="library_construction_method">-</dd>
       <dt>Library Prep Option</dt>	    <dd id="library_prep_option">-</dd>
       <dt>BioAnalyzer Run Required</dt>	<dd id="bioanalyzer_run_required">-</dd>
-      <dt>Last updated:</dt>            <dd><span id="last_update"></dd>
+      <dt>SC prep option (Hashing)</dt> <dd><span id="library_prep_option_single_cell_(hashing)">-</span></dd>
+      <dt>SC prep option (CITE)</dt>    <dd><span id="library_prep_option_single_cell_(cite)">-</span></dd>
+      <dt>SC prep option (VDJ)</dt>     <dd><span id="library_prep_option_single_cell_(vdj)">-</span></dd>
+      <dt>SC prep option (feature)</dt> <dd><span id="library_prep_option_single_cell_(feature)">-</span></dd>
+      <dt>Last updated:</dt>            <dd><span id="last_update"></span></dd>
 		</dl>
     <hr>
 


### PR DESCRIPTION
Not particularly happy with the placement, but I think it will have to wait for the new project page to be improved.

I wanted to make it conditionally show only for single cell projects but that wasn't as easy as I thought. It will also have to wait for the new project page.