### PR TITLE
Bugfix for ssl.SSLEOFError: EOF occurred in when running as cronjob

### DIFF
--- a/scripts/update_suggestion_box
+++ b/scripts/update_suggestion_box
@@ -57,7 +57,8 @@ def main(config):
             )
             continue
 
-    sb_database.update(docs)
+    if docs:
+        sb_database.update(docs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This should fix the script failing with the below error when run as a cronjob
ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:2417)