### PR TITLE
Handle columns with undefined values

### DIFF
--- a/run_dir/static/js/project_samples_old.js
+++ b/run_dir/static/js/project_samples_old.js
@@ -848,6 +848,9 @@ function load_samples_table(colOrder) {
                   }
                   tbl_row += '</td>';
                 }
+                else if (info[column_id] === undefined || info[column_id] === null || Object.keys(info[column_id]).length === 0){
+				          tbl_row += '<td class="'+column_id+'">'+'-</td>';
+			          }
               });
               tbl_row += '</tr>';
               tbl_body += tbl_row;


### PR DESCRIPTION
Resolves the below error on Library Validation on Samples tab
DataTables warning: table id=sample_table - Incorrect column count. For more information about this error, please see http://datatables.net/tn/18