### PR TITLE
Rework of reads aggregation page

### DIFF
--- a/run_dir/design/project_samples_old.html
+++ b/run_dir/design/project_samples_old.html
@@ -358,9 +358,6 @@ Description: Details page for a single project
             <!-- Load default presets (to be filled with JS) -->
           </div>
 
-          <div class="btn-group ml-4" role="group">
-          <a class="btn btn-sm btn-outline-secondary d-flex align-items-center" href='/reads_total/{{ project }}' role="button">Reads Aggregation</a>
-          </div>
           <div class="btn-group ml-1" role="group">
           <a class="btn btn-sm btn-outline-secondary d-flex align-items-center" href='/rec_ctrl_view/{{ project }}' role="button">RecCtrl Plates</a>
           </div>

--- a/run_dir/design/project_samples_old.html
+++ b/run_dir/design/project_samples_old.html
@@ -141,6 +141,7 @@ Description: Details page for a single project
     <li class="nav-item"><a class="nav-link" href="#tab_running_notes_content" role="tab" data-toggle="tab">Running Notes</a></li>
     <li class="nav-item"><a class="nav-link" href="#tab_com_content" role="tab" data-toggle="tab" id="tab_communication">User communication</a></li>
     <li class="nav-item"><a class="nav-link" href="#tab_links_content" role="tab" data-toggle="tab">Links</a></li>
+    <li class="nav-item"><a class="nav-link" href="/reads_total/{{ project }}" target="_blank" rel="noopener noreferrer">Read totals</a></li>
     <li class="nav-item dropdown"><a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" id="reports_dropdown">Reports</a>
       <div class="dropdown-menu" aria-labelledby="reports_dropdown">
         {% if not reports%}

--- a/run_dir/design/project_samples_old.html
+++ b/run_dir/design/project_samples_old.html
@@ -141,7 +141,7 @@ Description: Details page for a single project
     <li class="nav-item"><a class="nav-link" href="#tab_running_notes_content" role="tab" data-toggle="tab">Running Notes</a></li>
     <li class="nav-item"><a class="nav-link" href="#tab_com_content" role="tab" data-toggle="tab" id="tab_communication">User communication</a></li>
     <li class="nav-item"><a class="nav-link" href="#tab_links_content" role="tab" data-toggle="tab">Links</a></li>
-    <li class="nav-item"><a class="nav-link" href="/reads_total/{{ project }}" target="_blank" rel="noopener noreferrer">Read totals</a></li>
+    <li class="nav-item"><a class="nav-link" href="/read_totals/{{ project }}" target="_blank" rel="noopener noreferrer">Read totals</a></li>
     <li class="nav-item dropdown"><a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" id="reports_dropdown">Reports</a>
       <div class="dropdown-menu" aria-labelledby="reports_dropdown">
         {% if not reports%}

--- a/run_dir/design/read_totals.html
+++ b/run_dir/design/read_totals.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 
 <!--
-Template file: reads_total.html
-URL: /reads_total
+Template file: read_totals.html
+URL: /read_totals
 Title: Reads
 Description: Summing tool for the reads
 -->
 
 {% block stuff %}
-<div id="reads_total_app">
+<div id="read_totals_app">
     <v-reads-total-component :query="'{{ query }}'"></v-reads-total-component>
 </div>
 
@@ -17,6 +17,6 @@ Description: Summing tool for the reads
 <script src="/static/js/vue.v3.2.47.global.prod.js"></script>
 <script src="/static/js/axios.v1.11.0.min.js"></script>
 <script type="text/javascript" src="/static/js/FileSaver.min.js"></script>
-<script type="text/javascript" src="/static/js/reads_total.js?v={{ gs_globals['git_commit'] }}"></script>
+<script type="text/javascript" src="/static/js/read_totals.js?v={{ gs_globals['git_commit'] }}"></script>
 
 {% end %}

--- a/run_dir/static/js/projects_components.js
+++ b/run_dir/static/js/projects_components.js
@@ -445,6 +445,16 @@ export const vProjectDetails = {
                                     </template>
                                 </template>
                             </template>
+                            <div class="mt-1 pt-1 rounded-3">
+                                <h3 class="row mb-0">
+                                    <button class="btn btn-large badge text-primary border col-11" :href="'/reads_total/' + project_id" style="padding: 0.85rem !important;">
+                                        <a :href="'/reads_total/' + project_id" target="_blank" rel="noopener noreferrer" class="text-decoration-none row d-inline">
+                                            <span class="col-6 float-left text-left">Read totals</span>
+                                            <i class="fa-solid fa-chart-column float-right text-primary col-1 px-0"></i>
+                                        </a>
+                                    </button>
+                                </h3>
+                            </div>
                             <div v-if="'reports' in project_data && 'project_summary' in project_data.reports" class="mt-1 pt-1 rounded-3">
                                 <h3 class="row mb-0">
                                     <button class="btn btn-large badge text-primary border col-11" :href="'/proj_summary_report/'+project_id" style="padding: 0.85rem !important;">

--- a/run_dir/static/js/projects_components.js
+++ b/run_dir/static/js/projects_components.js
@@ -623,7 +623,7 @@ export const vProjectDetails = {
                     </dl>
                 </div>
                 <!-- TABS -->
-                <div class="col-12">
+                <div>
                     <ul class="nav nav-tabs" id="myTab" role="tablist">
                         <li class="nav-item" role="presentation">
                             <button class="nav-link active" ref="project-running-notes-pane-btn" @click="switchTab('project-running-notes-pane')" type="button" role="tab" aria-controls="project-running-notes-pane" aria-selected="true">Running Notes</button>
@@ -636,9 +636,6 @@ export const vProjectDetails = {
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link" ref="project-user-communication-pane-btn" @click="switchTab('project-user-communication-pane')" type="button" role="tab" aria-controls="project-user-communication-pane" aria-selected="false">User communication</button>
-                        </li>
-                        <li class="nav-item" role="presentation">
-                            <a class="nav-link" :href="'/reads_total/' + project_id" target="_blank" rel="noopener noreferrer">Read totals</a>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link" ref="project-agreements-pane-btn" @click="switchTab('project-agreements-pane')" type="button" role="tab" aria-controls="project-agreements-pane" aria-selected="false">Agreements</button>

--- a/run_dir/static/js/projects_components.js
+++ b/run_dir/static/js/projects_components.js
@@ -447,8 +447,8 @@ export const vProjectDetails = {
                             </template>
                             <div class="mt-1 pt-1 rounded-3">
                                 <h3 class="row mb-0">
-                                    <button class="btn btn-large badge text-primary border col-11" :href="'/reads_total/' + project_id" style="padding: 0.85rem !important;">
-                                        <a :href="'/reads_total/' + project_id" target="_blank" rel="noopener noreferrer" class="text-decoration-none row d-inline">
+                                    <button class="btn btn-large badge text-primary border col-11" :href="'/read_totals/' + project_id" style="padding: 0.85rem !important;">
+                                        <a :href="'/read_totals/' + project_id" target="_blank" rel="noopener noreferrer" class="text-decoration-none row d-inline">
                                             <span class="col-6 float-left text-left">Read totals</span>
                                             <i class="fa-solid fa-chart-column float-right text-primary col-1 px-0"></i>
                                         </a>

--- a/run_dir/static/js/projects_components.js
+++ b/run_dir/static/js/projects_components.js
@@ -623,7 +623,7 @@ export const vProjectDetails = {
                     </dl>
                 </div>
                 <!-- TABS -->
-                <div>
+                <div class="col-12">
                     <ul class="nav nav-tabs" id="myTab" role="tablist">
                         <li class="nav-item" role="presentation">
                             <button class="nav-link active" ref="project-running-notes-pane-btn" @click="switchTab('project-running-notes-pane')" type="button" role="tab" aria-controls="project-running-notes-pane" aria-selected="true">Running Notes</button>
@@ -636,6 +636,9 @@ export const vProjectDetails = {
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link" ref="project-user-communication-pane-btn" @click="switchTab('project-user-communication-pane')" type="button" role="tab" aria-controls="project-user-communication-pane" aria-selected="false">User communication</button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" :href="'/reads_total/' + project_id" target="_blank" rel="noopener noreferrer">Read totals</a>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link" ref="project-agreements-pane-btn" @click="switchTab('project-agreements-pane')" type="button" role="tab" aria-controls="project-agreements-pane" aria-selected="false">Agreements</button>

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -413,9 +413,11 @@ const vReadsTotalComponent = {
         },
         downloadMainTableTSV() {
             const rows = ['Sample\tReads\tQ30'];
-            this.summaryRows.forEach(r => {
-                const q30Value = r.avgQ30 === null ? '' : Number(r.avgQ30).toFixed(2);
-                rows.push(`${r.sample}\t${r.checkedReads}\t${q30Value}`);
+            this.sortedSampleNames.forEach(sample => {
+                const selectedReads = this.summaryRowMap[sample] || 0;
+                const avgQ30 = this.summaryRowQ30Map[sample];
+                const q30Value = avgQ30 === null || avgQ30 === undefined ? '' : Number(avgQ30).toFixed(2);
+                rows.push(`${sample}\t${selectedReads}\t${q30Value}`);
             });
             const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/tab-separated-values;charset=utf-8' });
             saveAs(blob, `${this.query}_read_totals.tsv`);

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -381,6 +381,21 @@ const vReadsTotalComponent = {
         sampleFlowcellCount(sample) {
             return (this.readsData[sample] || []).length;
         },
+        sampleTotalCount(sample) {
+            return (this.sampleRows(sample) || []).reduce((sum, d) => {
+                return sum + (Number.parseInt(d.cl, 10) || 0);
+            }, 0);
+        },
+        selectSamplesBelowExpectedMinYield() {
+            const threshold = Number(this.expectedMinYieldPerSample);
+            if (Number.isNaN(threshold)) return;
+            this.sampleNames.forEach(sample => {
+                const shouldSelect = this.sampleTotalCount(sample) < threshold;
+                this.sampleRows(sample).forEach(d => {
+                    this.checkedState[this.selectionKey(sample, d.fcp)] = shouldSelect;
+                });
+            });
+        },
         setSort(key) {
             if (this.sortKey === key) {
                 this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
@@ -411,7 +426,7 @@ const vReadsTotalComponent = {
             const sampleNames = this.summaryRows.map(r => r.sample);
             const seriesData = [
                 { name: 'q30>threshold', data: [], color: '#78b560' },
-                { name: 'q30<threshold', data: [], color: '#e8cd4c' },
+                { name: 'q30&lt;threshold', data: [], color: '#e8cd4c' },
                 { name: 'Not Selected',  data: [], color: '#dddddd' }
             ];
             this.summaryRows.forEach(r => {
@@ -500,6 +515,7 @@ const vReadsTotalComponent = {
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>
                     <input type="button" class="btn btn-outline-secondary" :value="areAllSamplesExpanded ? 'Collapse all' : 'Expand all'" @click="toggleAllSamplesExpanded"/>
                     <input type="button" class="btn btn-outline-secondary" :value="showFlowcellSelection ? 'Hide flowcell selection' : 'Select flowcells'" @click="toggleFlowcellSelection"/>
+                    <input type="button" class="btn btn-outline-warning" value="Select below expected min yield" :disabled="expectedMinYieldPerSample === null" @click="selectSamplesBelowExpectedMinYield"/>
                     <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
                 </div>
                 <div class="d-flex flex-wrap gap-2 mb-3">

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -604,7 +604,7 @@ const vReadsTotalComponent = {
                         <tbody>
                             <template v-for="sample in sortedSampleNames" :key="sample">
                                 <tr :id="sample" class="sample_table"
-                                    :class="{ highlighted: highlightedSample === sample, 'table-secondary': !isSampleChecked(sample) }"
+                                    :class="{ highlighted: highlightedSample === sample, 'table-secondary': !isSampleChecked(sample), 'text-muted': !isSampleChecked(sample) }"
                                     style="cursor: pointer; transition: background-color 0.15s ease;"
                                     @click="toggleSampleExpanded(sample)">
                                     <td>
@@ -637,9 +637,9 @@ const vReadsTotalComponent = {
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                                <tr v-for="d in sampleRows(sample)" :key="d.fcp" :class="{ 'table-secondary': !checkedState[selectionKey(sample, d.fcp)] }">
+                                                <tr v-for="d in sampleRows(sample)" :key="d.fcp" :class="{ 'table-secondary': !checkedState[selectionKey(sample, d.fcp)], 'text-muted': !checkedState[selectionKey(sample, d.fcp)] }">
                                                     <td><input type="checkbox" v-model="checkedState[selectionKey(sample, d.fcp)]"/></td>
-                                                    <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
+                                                    <td><a :class="{ 'text-decoration-none': true, 'text-muted': !checkedState[selectionKey(sample, d.fcp)] }" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
                                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ Number(d.cl).toLocaleString() }}</td>
                                                     <td class="text-end" :class="q30Class(d)" style="font-variant-numeric: tabular-nums;">{{ d.q30 }}</td>
                                                 </tr>

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -381,8 +381,9 @@ const vReadsTotalComponent = {
         sampleFlowcellCount(sample) {
             return (this.readsData[sample] || []).length;
         },
-        sampleTotalCount(sample) {
+        sampleSelectedCount(sample) {
             return (this.sampleRows(sample) || []).reduce((sum, d) => {
+                if (!this.checkedState[this.selectionKey(sample, d.fcp)]) return sum;
                 return sum + (Number.parseInt(d.cl, 10) || 0);
             }, 0);
         },
@@ -390,9 +391,11 @@ const vReadsTotalComponent = {
             const threshold = Number(this.expectedMinYieldPerSample);
             if (Number.isNaN(threshold)) return;
             this.sampleNames.forEach(sample => {
-                const shouldSelect = this.sampleTotalCount(sample) < threshold;
+                const shouldSelect = this.sampleSelectedCount(sample) < threshold;
                 this.sampleRows(sample).forEach(d => {
-                    this.checkedState[this.selectionKey(sample, d.fcp)] = shouldSelect;
+                    if (!shouldSelect) {
+                        this.checkedState[this.selectionKey(sample, d.fcp)] = false;
+                    }
                 });
             });
         },

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -420,13 +420,7 @@ const vReadsTotalComponent = {
             const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/tab-separated-values;charset=utf-8' });
             saveAs(blob, `${this.query}_read_totals.tsv`);
         },
-        renderChart() {
-            if (!this.hasData) return;
-            if (this.chartInstance) {
-                this.chartInstance.destroy();
-                this.chartInstance = null;
-            }
-            const sampleNames = this.summaryRows.map(r => r.sample);
+        buildChartSeriesData() {
             const seriesData = [
                 { name: 'q30>threshold', data: [], color: '#78b560' },
                 { name: 'q30&lt;threshold', data: [], color: '#e8cd4c' },
@@ -442,6 +436,47 @@ const vReadsTotalComponent = {
                 }
                 seriesData[2].data.push(r.uncheckedReads);
             });
+            return seriesData;
+        },
+        expectedMinYieldPlotLine() {
+            if (this.expectedMinYieldPerSample === null) {
+                return null;
+            }
+            return {
+                id: 'expected-min-yield',
+                color: '#fd0d0d',
+                dashStyle: 'ShortDash',
+                value: this.expectedMinYieldPerSample,
+                width: 2,
+                zIndex: 5,
+                label: {
+                    text: 'Expected minimum yield',
+                    align: 'right',
+                    style: { color: '#fd0d0d' }
+                }
+            };
+        },
+        renderChart() {
+            if (!this.hasData) return;
+            const sampleNames = this.summaryRows.map(r => r.sample);
+            const seriesData = this.buildChartSeriesData();
+            const plotLine = this.expectedMinYieldPlotLine();
+
+            if (this.chartInstance) {
+                this.chartInstance.xAxis[0].setCategories(sampleNames, false);
+                this.chartInstance.yAxis[0].setTitle({ text: '# ' + this.countLabel }, false);
+                this.chartInstance.yAxis[0].removePlotLine('expected-min-yield');
+                if (plotLine) {
+                    this.chartInstance.yAxis[0].addPlotLine(plotLine);
+                }
+                seriesData.forEach((series, index) => {
+                    this.chartInstance.series[index].update({ name: series.name, color: series.color }, false);
+                    this.chartInstance.series[index].setData(series.data, false);
+                });
+                this.chartInstance.redraw();
+                return;
+            }
+
             this.chartInstance = Highcharts.chart('read_totals_summary_chart', {
                 credits: { enabled: false },
                 chart: { type: 'column' },
@@ -452,18 +487,7 @@ const vReadsTotalComponent = {
                     min: 0,
                     title: { text: '# ' + this.countLabel },
                     reversedStacks: false,
-                    plotLines: this.expectedMinYieldPerSample !== null ? [{
-                        color: '#fd0d0d',
-                        dashStyle: 'ShortDash',
-                        value: this.expectedMinYieldPerSample,
-                        width: 2,
-                        zIndex: 5,
-                        label: {
-                            text: 'Expected minimum yield',
-                            align: 'right',
-                            style: { color: '#fd0d0d' }
-                        }
-                    }] : []
+                    plotLines: plotLine ? [plotLine] : []
                 },
                 plotOptions: {
                     column: { stacking: 'normal', borderWidth: 0, groupPadding: 0.1 },

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -311,7 +311,12 @@ const vReadsTotalComponent = {
             this.$nextTick(() => {
                 const el = document.getElementById(sample);
                 if (el) {
-                    el.scrollIntoView({ behavior: 'smooth' });
+                    const fixedHeader = document.querySelector('nav.navbar.fixed-top');
+                    const headerHeight = fixedHeader ? fixedHeader.getBoundingClientRect().height : 0;
+                    const topGap = 12;
+                    const scrollOffset = headerHeight + topGap;
+                    const targetTop = el.getBoundingClientRect().top + window.pageYOffset - scrollOffset;
+                    window.scrollTo({ top: Math.max(targetTop, 0), behavior: 'smooth' });
                     location.hash = '#' + sample;
                 }
             });

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -1,4 +1,4 @@
-// Used by reads_total.html
+// Used by read_totals.html
 
 // Component definition - can be imported and used in other Vue apps
 const vReadsTotalComponent = {
@@ -192,7 +192,7 @@ const vReadsTotalComponent = {
     
     methods: {
         fetchData() {
-            axios.get(`/api/v1/reads_total/${this.query}`)
+            axios.get(`/api/v1/read_totals/${this.query}`)
                 .then(response => {
                     const data = response.data;
                     this.isHiseqX = data.isHiseqX || false;
@@ -386,7 +386,7 @@ const vReadsTotalComponent = {
                 rows.push(`${r.sample}\t${r.checkedReads}\t${q30Value}`);
             });
             const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/tab-separated-values;charset=utf-8' });
-            saveAs(blob, `${this.query}_reads_total.tsv`);
+            saveAs(blob, `${this.query}_read_totals.tsv`);
         },
         renderChart() {
             if (!this.hasData) return;
@@ -410,7 +410,7 @@ const vReadsTotalComponent = {
                 }
                 seriesData[2].data.push(r.uncheckedReads);
             });
-            this.chartInstance = Highcharts.chart('reads_total_summary_chart', {
+            this.chartInstance = Highcharts.chart('read_totals_summary_chart', {
                 credits: { enabled: false },
                 chart: { type: 'column' },
                 title: { text: 'Sample Read Counts' },
@@ -450,7 +450,7 @@ const vReadsTotalComponent = {
     },
     template: /*html*/`
         <div>
-            <h1>Read Count Totals: <a :href="'/project/' + query" target="_blank" rel="noopener noreferrer" class="text-decoration-none">{{ query }}</a></h1>
+            <h1>Read Totals for <a :href="'/project/' + query" target="_blank" rel="noopener noreferrer" class="text-decoration-none">{{ query }}</a></h1>
         </div>
 
         <template v-if="loading && query">
@@ -474,7 +474,7 @@ const vReadsTotalComponent = {
 
         <template v-else-if="hasData">
             <div>
-                <div id="reads_total_summary_chart"></div>
+                <div id="read_totals_summary_chart"></div>
                 <p v-if="expectedMinYieldPerSample !== null" class="text-muted small mb-3">
                     Expected minimum yield / sample threshold: <strong>{{ formattedExpectedMinYieldPerSample }}</strong> reads/sample.
                     Formula: ordered lanes × 600M × 0.9 × 0.75 / number of project samples.
@@ -611,4 +611,4 @@ const vReadsTotalComponent = {
       return { query: "{{ query }}" };
     }
   });
-  app.mount('#reads_total_app');
+    app.mount('#read_totals_app');

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -14,6 +14,7 @@ const vReadsTotalComponent = {
             readsData: {},
             isHiseqX: false,
             expectedMinYieldPerSample: null,
+            expectedMinYieldFormulaMode: null,
             showFlowcellSelection: false,
             bulkSelectedFlowcells: {},
             highlightedSample: null,
@@ -175,6 +176,12 @@ const vReadsTotalComponent = {
             }
             return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value);
         },
+        expectedMinYieldFormulaText() {
+            if (this.expectedMinYieldFormulaMode === 'lanes') {
+                return 'ordered lanes × lane threshold × 0.9 / number of project samples × 0.75.';
+            }
+            return 'ordered units × 600M × 0.9 / number of project samples × 0.75.';
+        },
     },
     
     watch: {
@@ -197,8 +204,10 @@ const vReadsTotalComponent = {
                     const data = response.data;
                     this.isHiseqX = data.isHiseqX || false;
                     this.expectedMinYieldPerSample = data.expectedMinYieldPerSample ?? null;
+                    this.expectedMinYieldFormulaMode = data.expectedMinYieldFormulaMode ?? null;
                     delete data.isHiseqX;
                     delete data.expectedMinYieldPerSample;
+                    delete data.expectedMinYieldFormulaMode;
                     this.readsData = data;
                     
                     // Initialize checkbox state
@@ -427,7 +436,7 @@ const vReadsTotalComponent = {
                         width: 2,
                         zIndex: 5,
                         label: {
-                            text: 'Expected minimum yield / sample',
+                            text: 'Expected minimum yield',
                             align: 'right',
                             style: { color: '#fd0d0d' }
                         }
@@ -476,8 +485,11 @@ const vReadsTotalComponent = {
             <div>
                 <div id="read_totals_summary_chart"></div>
                 <p v-if="expectedMinYieldPerSample !== null" class="text-muted small mb-3">
-                    Expected minimum yield / sample threshold: <strong>{{ formattedExpectedMinYieldPerSample }}</strong> reads/sample.
-                    Formula: ordered lanes × 600M × 0.9 × 0.75 / number of project samples.
+                    Expected minimum yield per sample:
+                    <strong
+                        :title="'Formula: ' + expectedMinYieldFormulaText"
+                        style="text-decoration: underline dotted; cursor: help;"
+                    >{{ formattedExpectedMinYieldPerSample }}</strong>.
                 </p>
                 <div class="btn-group mb-3" role="group">
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>

--- a/run_dir/static/js/read_totals.js
+++ b/run_dir/static/js/read_totals.js
@@ -518,7 +518,6 @@ const vReadsTotalComponent = {
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>
                     <input type="button" class="btn btn-outline-secondary" :value="areAllSamplesExpanded ? 'Collapse all' : 'Expand all'" @click="toggleAllSamplesExpanded"/>
                     <input type="button" class="btn btn-outline-secondary" :value="showFlowcellSelection ? 'Hide flowcell selection' : 'Select flowcells'" @click="toggleFlowcellSelection"/>
-                    <input type="button" class="btn btn-outline-warning" value="Select below expected min yield" :disabled="expectedMinYieldPerSample === null" @click="selectSamplesBelowExpectedMinYield"/>
                     <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
                 </div>
                 <div class="d-flex flex-wrap gap-2 mb-3">
@@ -537,6 +536,14 @@ const vReadsTotalComponent = {
                         @click="toggleSamplesByLibQc('Fail')"
                     >
                         {{ areSamplesFullyChecked(failedLibQcSamples) ? 'Uncheck' : 'Check' }} Fail QC samples
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-outline-warning rounded-pill"
+                        :disabled="expectedMinYieldPerSample === null"
+                        @click="selectSamplesBelowExpectedMinYield"
+                    >
+                        Check all samples below yield threshold
                     </button>
                 </div>
                 <div v-if="showFlowcellSelection" class="card mb-3">

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -607,7 +607,7 @@ const vReadsTotalComponent = {
                                                 <tr v-for="d in readsData[sample]" :key="d.fcp">
                                                     <td><input type="checkbox" v-model="checkedState[sample + '_' + d.fcp]"/></td>
                                                     <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
-                                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ d.cl }}</td>
+                                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ Number(d.cl).toLocaleString() }}</td>
                                                     <td class="text-end" :class="q30Class(d)" style="font-variant-numeric: tabular-nums;">{{ d.q30 }}</td>
                                                 </tr>
                                             </tbody>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -13,7 +13,9 @@ const vReadsTotalComponent = {
             },
             readsData: {},
             isHiseqX: false,
-            checkKeyFilter: '',
+            showBulkFlowcellEditor: false,
+            bulkFlowcellSearch: '',
+            bulkSelectedFlowcells: {},
             highlightedSample: null,
             checkedState: {},
             expandedSamples: {},
@@ -63,8 +65,51 @@ const vReadsTotalComponent = {
             this.summaryRows.forEach(r => { map[r.sample] = r.avgQ30; });
             return map;
         },
+        allFlowcellIds() {
+            const ids = new Set();
+            this.sampleNames.forEach(sample => {
+                (this.readsData[sample] || []).forEach(d => {
+                    ids.add(d.fcp);
+                });
+            });
+            return Array.from(ids).sort();
+        },
+        filteredFlowcellIds() {
+            const filter = this.bulkFlowcellSearch.trim().toLowerCase();
+            if (!filter) return this.allFlowcellIds;
+            return this.allFlowcellIds.filter(id => id.toLowerCase().includes(filter));
+        },
+        selectedFlowcellIds() {
+            return this.allFlowcellIds.filter(id => this.bulkSelectedFlowcells[id]);
+        },
+        selectedFlowcellIdSet() {
+            return new Set(this.selectedFlowcellIds);
+        },
+        bulkAffectedRowsCount() {
+            const selectedSet = this.selectedFlowcellIdSet;
+            let count = 0;
+            if (selectedSet.size === 0) return 0;
+            this.sampleNames.forEach(sample => {
+                (this.readsData[sample] || []).forEach(d => {
+                    if (selectedSet.has(d.fcp)) count += 1;
+                });
+            });
+            return count;
+        },
+        bulkAffectedSamplesCount() {
+            const selectedSet = this.selectedFlowcellIdSet;
+            if (selectedSet.size === 0) return 0;
+            return this.sampleNames.filter(sample => {
+                return (this.readsData[sample] || []).some(d => selectedSet.has(d.fcp));
+            }).length;
+        },
         totalClusters() {
             return this.summaryRows.reduce((sum, r) => sum + r.checkedReads, 0);
+        },
+        isAllSelected() {
+            const keys = Object.keys(this.checkedState);
+            if (keys.length === 0) return false;
+            return keys.every(key => this.checkedState[key]);
         },
         countLabel() {
             return this.isHiseqX ? 'Clusters' : 'Reads';
@@ -104,6 +149,9 @@ const vReadsTotalComponent = {
                     this.sampleNames.forEach(sample => {
                         this.expandedSamples[sample] = false;
                     });
+                    this.bulkSelectedFlowcells = {};
+                    this.bulkFlowcellSearch = '';
+                    this.showBulkFlowcellEditor = false;
                     
                     this.loading = false;
                     this.$nextTick(() => this.renderChart());
@@ -148,16 +196,10 @@ const vReadsTotalComponent = {
         projectFromSample(sample) {
             return sample.split('_')[0];
         },
-        checkAll() {
-            const filter = this.checkKeyFilter;
+        toggleAllSelection() {
+            const nextValue = !this.isAllSelected;
             Object.keys(this.checkedState).forEach(key => {
-                if (key.includes(filter)) this.checkedState[key] = true;
-            });
-        },
-        uncheckAll() {
-            const filter = this.checkKeyFilter;
-            Object.keys(this.checkedState).forEach(key => {
-                if (key.includes(filter)) this.checkedState[key] = false;
+                this.checkedState[key] = nextValue;
             });
         },
         highlightSample(sample) {
@@ -194,6 +236,33 @@ const vReadsTotalComponent = {
         formatQ30(value) {
             if (value === null || value === undefined) return '-';
             return Number(value).toFixed(2);
+        },
+        toggleBulkFlowcellEditor() {
+            this.showBulkFlowcellEditor = !this.showBulkFlowcellEditor;
+        },
+        selectVisibleFlowcells() {
+            this.filteredFlowcellIds.forEach(id => {
+                this.bulkSelectedFlowcells[id] = true;
+            });
+        },
+        clearVisibleFlowcells() {
+            this.filteredFlowcellIds.forEach(id => {
+                this.bulkSelectedFlowcells[id] = false;
+            });
+        },
+        clearAllBulkSelections() {
+            this.bulkSelectedFlowcells = {};
+        },
+        applyBulkFlowcellSelection(isChecked) {
+            const selectedSet = this.selectedFlowcellIdSet;
+            if (selectedSet.size === 0) return;
+            this.sampleNames.forEach(sample => {
+                (this.readsData[sample] || []).forEach(d => {
+                    if (selectedSet.has(d.fcp)) {
+                        this.checkedState[`${sample}_${d.fcp}`] = isChecked;
+                    }
+                });
+            });
         },
         downloadMainTableTSV() {
             const rows = [`Sample\tFlowcell\tQ30\tSelected\t${this.countLabel}`];
@@ -308,10 +377,40 @@ const vReadsTotalComponent = {
             <div>
                 <div id="reads_total_summary_chart"></div>
                 <div class="btn-group mb-3" role="group">
-                    <input type="button" class="btn btn-outline-secondary" value="Check all" @click="checkAll"/>
-                    <input type="button" class="btn btn-outline-secondary" value="Uncheck all" @click="uncheckAll"/>
+                    <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>
+                    <input type="button" class="btn btn-outline-secondary" :value="showBulkFlowcellEditor ? 'Hide bulk flowcell editor' : 'Bulk edit flowcells'" @click="toggleBulkFlowcellEditor"/>
                     <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
-                    <input type="text" class="form-control" v-model="checkKeyFilter"/>
+                </div>
+                <div v-if="showBulkFlowcellEditor" class="card mb-3">
+                    <div class="card-body">
+                        <div class="d-flex flex-wrap align-items-end gap-2 mb-3">
+                            <div style="min-width: 260px;">
+                                <label class="form-label fw-bold" for="bulk_flowcell_search">Find flowcell or lane</label>
+                                <input id="bulk_flowcell_search" type="text" class="form-control" v-model="bulkFlowcellSearch" placeholder="Search IDs"/>
+                            </div>
+                            <input type="button" class="btn btn-outline-secondary" value="Select visible" @click="selectVisibleFlowcells"/>
+                            <input type="button" class="btn btn-outline-secondary" value="Clear visible" @click="clearVisibleFlowcells"/>
+                            <input type="button" class="btn btn-outline-secondary" value="Clear selected IDs" @click="clearAllBulkSelections"/>
+                        </div>
+
+                        <p class="mb-2">
+                            Selected IDs: {{ selectedFlowcellIds.length }}.
+                            Matching rows: {{ bulkAffectedRowsCount }} across {{ bulkAffectedSamplesCount }} samples.
+                        </p>
+
+                        <div style="max-height: 220px; overflow: auto; border: 1px solid #d9d9d9; border-radius: 4px; padding: 8px;">
+                            <div v-if="filteredFlowcellIds.length === 0" class="text-muted">No flowcell/lane IDs match this search.</div>
+                            <div v-for="id in filteredFlowcellIds" :key="id" class="form-check">
+                                <input class="form-check-input" type="checkbox" :id="'bulk_' + id" v-model="bulkSelectedFlowcells[id]"/>
+                                <label class="form-check-label" :for="'bulk_' + id">{{ id }}</label>
+                            </div>
+                        </div>
+
+                        <div class="d-flex gap-2 mt-3">
+                            <input type="button" class="btn btn-primary" value="Check selected IDs across all samples" :disabled="selectedFlowcellIds.length === 0" @click="applyBulkFlowcellSelection(true)"/>
+                            <input type="button" class="btn btn-outline-primary" value="Uncheck selected IDs across all samples" :disabled="selectedFlowcellIds.length === 0" @click="applyBulkFlowcellSelection(false)"/>
+                        </div>
+                    </div>
                 </div>
                 <div class="container-fluid">
                     <table class="table reads_table">

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -19,6 +19,8 @@ const vReadsTotalComponent = {
             highlightedSample: null,
             checkedState: {},
             expandedSamples: {},
+            sortKey: 'sample',
+            sortDirection: 'asc',
             chartInstance: null,
             loading: true,
             error: null,
@@ -64,6 +66,28 @@ const vReadsTotalComponent = {
             const map = {};
             this.summaryRows.forEach(r => { map[r.sample] = r.avgQ30; });
             return map;
+        },
+        sortedSampleNames() {
+            const direction = this.sortDirection === 'asc' ? 1 : -1;
+            return [...this.sampleNames].sort((leftSample, rightSample) => {
+                let leftValue;
+                let rightValue;
+
+                if (this.sortKey === 'reads') {
+                    leftValue = this.summaryRowMap[leftSample] || 0;
+                    rightValue = this.summaryRowMap[rightSample] || 0;
+                } else if (this.sortKey === 'q30') {
+                    leftValue = this.summaryRowQ30Map[leftSample] ?? -1;
+                    rightValue = this.summaryRowQ30Map[rightSample] ?? -1;
+                } else {
+                    leftValue = leftSample;
+                    rightValue = rightSample;
+                }
+
+                if (leftValue < rightValue) return -1 * direction;
+                if (leftValue > rightValue) return 1 * direction;
+                return leftSample.localeCompare(rightSample);
+            });
         },
         allFlowcellIds() {
             const ids = new Set();
@@ -277,6 +301,18 @@ const vReadsTotalComponent = {
         sampleFlowcellCount(sample) {
             return (this.readsData[sample] || []).length;
         },
+        setSort(key) {
+            if (this.sortKey === key) {
+                this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+                return;
+            }
+            this.sortKey = key;
+            this.sortDirection = key === 'sample' ? 'asc' : 'desc';
+        },
+        sortIndicator(key) {
+            if (this.sortKey !== key) return '';
+            return this.sortDirection === 'asc' ? '▲' : '▼';
+        },
         downloadMainTableTSV() {
             const rows = ['Sample\tReads\tQ30'];
             this.summaryRows.forEach(r => {
@@ -427,14 +463,14 @@ const vReadsTotalComponent = {
                         <thead>
                             <tr class="darkth">
                                 <th style="position: sticky; top: 0; z-index: 2;">Include</th>
-                                <th style="position: sticky; top: 0; z-index: 2;">Sample</th>
+                                <th style="position: sticky; top: 0; z-index: 2; cursor: pointer;" @click="setSort('sample')">Sample <span>{{ sortIndicator('sample') }}</span></th>
                                 <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">Flowcells</th>
-                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">{{ countLabel }} (selected)</th>
-                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">Average % > q30 (selected)</th>
+                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums; cursor: pointer;" @click="setSort('reads')">{{ countLabel }} (selected) <span>{{ sortIndicator('reads') }}</span></th>
+                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums; cursor: pointer;" @click="setSort('q30')">Average % > q30 (selected) <span>{{ sortIndicator('q30') }}</span></th>
                             </tr>
                         </thead>
                         <tbody>
-                            <template v-for="sample in sampleNames" :key="sample">
+                            <template v-for="sample in sortedSampleNames" :key="sample">
                                 <tr :id="sample" class="sample_table"
                                     :class="{ highlighted: highlightedSample === sample }"
                                     style="cursor: pointer; transition: background-color 0.15s ease;"

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -164,6 +164,23 @@ const vReadsTotalComponent = {
         countLabel() {
             return this.isHiseqX ? 'Clusters' : 'Reads';
         },
+        formattedExpectedMinYieldPerSample() {
+            if (this.expectedMinYieldPerSample === null || Number.isNaN(Number(this.expectedMinYieldPerSample))) {
+                return null;
+            }
+            const value = Number(this.expectedMinYieldPerSample);
+            const abs = Math.abs(value);
+            if (abs >= 1_000_000_000) {
+                return `${(value / 1_000_000_000).toFixed(2)}B`;
+            }
+            if (abs >= 1_000_000) {
+                return `${(value / 1_000_000).toFixed(2)}M`;
+            }
+            if (abs >= 1_000) {
+                return `${(value / 1_000).toFixed(2)}k`;
+            }
+            return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value);
+        },
     },
     
     watch: {
@@ -480,7 +497,8 @@ const vReadsTotalComponent = {
             <div>
                 <div id="reads_total_summary_chart"></div>
                 <p v-if="expectedMinYieldPerSample !== null" class="text-muted small mb-3">
-                    Expected minimum yield / sample line = ordered lanes x 600M x 0.9 x 0.75 / number of project samples.
+                    Expected minimum yield / sample threshold: <strong>{{ formattedExpectedMinYieldPerSample }}</strong> reads/sample.
+                    Formula: ordered lanes × 600M × 0.9 × 0.75 / number of project samples.
                 </p>
                 <div class="btn-group mb-3" role="group">
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -40,8 +40,8 @@ const vReadsTotalComponent = {
                 let checkedReads = 0, uncheckedReads = 0, q30Sum = 0, checkedQ30Count = 0;
                 const rows = this.readsData[sample];
                 rows.forEach(d => {
-                    const count = parseInt(d.cl) || 0;
-                    if (this.checkedState[`${sample}_${d.fcp}`]) {
+                    const count = Number.parseInt(d.cl, 10) || 0;
+                    if (this.checkedState[this.selectionKey(sample, d.fcp)]) {
                         checkedReads += count;
                         const q30 = parseFloat(d.q30);
                         if (!Number.isNaN(q30)) {
@@ -249,7 +249,19 @@ const vReadsTotalComponent = {
             return 'table-warning';
         },
         sampleLibQcLabel(sample) {
-            const value = this.summaryRowLibQcMap[sample];
+            return this.normalizedLibQcLabel(this.summaryRowLibQcMap[sample]);
+        },
+        sampleLibQcBadgeClass(sample) {
+            const label = this.sampleLibQcLabel(sample);
+            if (label === 'Pass') {
+                return 'badge bg-success rounded-pill';
+            }
+            if (label === 'Fail') {
+                return 'badge bg-danger rounded-pill';
+            }
+            return 'badge bg-secondary rounded-pill';
+        },
+        normalizedLibQcLabel(value) {
             if (value === true || value === 'True' || value === 'true') {
                 return 'Pass';
             }
@@ -258,23 +270,16 @@ const vReadsTotalComponent = {
             }
             return '-';
         },
-        sampleLibQcBadgeClass(sample) {
-            const value = this.summaryRowLibQcMap[sample];
-            if (value === true || value === 'True' || value === 'true') {
-                return 'badge bg-success rounded-pill';
-            }
-            if (value === false || value === 'False' || value === 'false') {
-                return 'badge bg-danger rounded-pill';
-            }
-            return 'badge bg-secondary rounded-pill';
+        sampleRows(sample) {
+            return this.readsData[sample] || [];
+        },
+        selectionKey(sample, fcp) {
+            return `${sample}_${fcp}`;
         },
         fcpFlowcellUrl(fcp) {
             const parts = fcp.split('_');
             const lastPart = parts[parts.length - 1].split(':')[0];
             return `/flowcells/${parts[0]}_${lastPart}`;
-        },
-        projectFromSample(sample) {
-            return sample.split('_')[0];
         },
         toggleAllSelection() {
             const nextValue = !this.isAllSelected;
@@ -297,20 +302,20 @@ const vReadsTotalComponent = {
             this.expandedSamples[sample] = !this.expandedSamples[sample];
         },
         isSampleChecked(sample) {
-            const rows = this.readsData[sample] || [];
+            const rows = this.sampleRows(sample);
             if (rows.length === 0) return false;
-            return rows.every(d => this.checkedState[`${sample}_${d.fcp}`]);
+            return rows.every(d => this.checkedState[this.selectionKey(sample, d.fcp)]);
         },
         isSampleIndeterminate(sample) {
-            const rows = this.readsData[sample] || [];
+            const rows = this.sampleRows(sample);
             if (rows.length === 0) return false;
-            const selectedCount = rows.filter(d => this.checkedState[`${sample}_${d.fcp}`]).length;
+            const selectedCount = rows.filter(d => this.checkedState[this.selectionKey(sample, d.fcp)]).length;
             return selectedCount > 0 && selectedCount < rows.length;
         },
         onSampleCheckboxChange(sample, event) {
             const isChecked = event.target.checked;
-            (this.readsData[sample] || []).forEach(d => {
-                this.checkedState[`${sample}_${d.fcp}`] = isChecked;
+            this.sampleRows(sample).forEach(d => {
+                this.checkedState[this.selectionKey(sample, d.fcp)] = isChecked;
             });
         },
         areSamplesFullyChecked(samples) {
@@ -321,8 +326,8 @@ const vReadsTotalComponent = {
             const samples = label === 'Pass' ? this.passedLibQcSamples : this.failedLibQcSamples;
             const nextValue = !this.areSamplesFullyChecked(samples);
             samples.forEach(sample => {
-                (this.readsData[sample] || []).forEach(d => {
-                    this.checkedState[`${sample}_${d.fcp}`] = nextValue;
+                this.sampleRows(sample).forEach(d => {
+                    this.checkedState[this.selectionKey(sample, d.fcp)] = nextValue;
                 });
             });
         },
@@ -350,9 +355,9 @@ const vReadsTotalComponent = {
             const selectedSet = this.selectedFlowcellIdSet;
             if (selectedSet.size === 0) return;
             this.sampleNames.forEach(sample => {
-                (this.readsData[sample] || []).forEach(d => {
+                this.sampleRows(sample).forEach(d => {
                     if (selectedSet.has(d.fcp)) {
-                        this.checkedState[`${sample}_${d.fcp}`] = isChecked;
+                        this.checkedState[this.selectionKey(sample, d.fcp)] = isChecked;
                     }
                 });
             });
@@ -604,8 +609,8 @@ const vReadsTotalComponent = {
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                                <tr v-for="d in readsData[sample]" :key="d.fcp">
-                                                    <td><input type="checkbox" v-model="checkedState[sample + '_' + d.fcp]"/></td>
+                                                <tr v-for="d in sampleRows(sample)" :key="d.fcp">
+                                                    <td><input type="checkbox" v-model="checkedState[selectionKey(sample, d.fcp)]"/></td>
                                                     <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
                                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ Number(d.cl).toLocaleString() }}</td>
                                                     <td class="text-end" :class="q30Class(d)" style="font-variant-numeric: tabular-nums;">{{ d.q30 }}</td>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -450,7 +450,7 @@ const vReadsTotalComponent = {
     },
     template: /*html*/`
         <div>
-            <h1>Read Count Totals: <span>{{ query }}</span></h1>
+            <h1>Read Count Totals: <a :href="'/project/' + query" target="_blank" rel="noopener noreferrer" class="text-decoration-none">{{ query }}</a></h1>
         </div>
 
         <template v-if="loading && query">

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -216,6 +216,14 @@ const vReadsTotalComponent = {
             }
             return 'table-warning';
         },
+        sampleQ30Class(sample) {
+            const row = this.summaryRows.find(r => r.sample === sample);
+            if (!row || row.avgQ30 === null) return '';
+            if (row.avgQ30 >= row.threshold) {
+                return 'table-success';
+            }
+            return 'table-warning';
+        },
         fcpFlowcellUrl(fcp) {
             const parts = fcp.split('_');
             const lastPart = parts[parts.length - 1].split(':')[0];
@@ -490,7 +498,7 @@ const vReadsTotalComponent = {
                                     </td>
                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ sampleFlowcellCount(sample) }}</td>
                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ summaryRowMap[sample].toLocaleString() }}</td>
-                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
+                                    <td class="text-end" :class="sampleQ30Class(sample)" style="font-variant-numeric: tabular-nums;">{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
                                 </tr>
                                 <tr v-if="expandedSamples[sample]">
                                     <td colspan="5" style="padding: 0 0 10px 30px;">

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -54,7 +54,10 @@ const vReadsTotalComponent = {
                 const avgQ30 = checkedQ30Count > 0 ? q30Sum / checkedQ30Count : null;
                 const firstRow = rows.find(d => d.run_mode != null) || rows[0];
                 const threshold = firstRow ? this.getRowThreshold(firstRow) : 85.0;
-                return { sample, checkedReads, uncheckedReads, avgQ30, threshold };
+                const libQc = firstRow && Object.prototype.hasOwnProperty.call(firstRow, 'lib_qc')
+                    ? firstRow.lib_qc
+                    : '-';
+                return { sample, checkedReads, uncheckedReads, avgQ30, threshold, libQc };
             });
         },
         summaryRowMap() {
@@ -67,6 +70,11 @@ const vReadsTotalComponent = {
             this.summaryRows.forEach(r => { map[r.sample] = r.avgQ30; });
             return map;
         },
+        summaryRowLibQcMap() {
+            const map = {};
+            this.summaryRows.forEach(r => { map[r.sample] = r.libQc; });
+            return map;
+        },
         sortedSampleNames() {
             const direction = this.sortDirection === 'asc' ? 1 : -1;
             return [...this.sampleNames].sort((leftSample, rightSample) => {
@@ -76,6 +84,13 @@ const vReadsTotalComponent = {
                 if (this.sortKey === 'reads') {
                     leftValue = this.summaryRowMap[leftSample] || 0;
                     rightValue = this.summaryRowMap[rightSample] || 0;
+                } else if (this.sortKey === 'flowcells') {
+                    leftValue = this.sampleFlowcellCount(leftSample);
+                    rightValue = this.sampleFlowcellCount(rightSample);
+                } else if (this.sortKey === 'libQc') {
+                    const libQcOrder = { Pass: 2, Fail: 1, '-': 0 };
+                    leftValue = libQcOrder[this.sampleLibQcLabel(leftSample)] ?? -1;
+                    rightValue = libQcOrder[this.sampleLibQcLabel(rightSample)] ?? -1;
                 } else if (this.sortKey === 'q30') {
                     leftValue = this.summaryRowQ30Map[leftSample] ?? -1;
                     rightValue = this.summaryRowQ30Map[rightSample] ?? -1;
@@ -138,6 +153,12 @@ const vReadsTotalComponent = {
         areAllSamplesExpanded() {
             if (this.sampleNames.length === 0) return false;
             return this.sampleNames.every(sample => this.expandedSamples[sample]);
+        },
+        passedLibQcSamples() {
+            return this.sampleNames.filter(sample => this.sampleLibQcLabel(sample) === 'Pass');
+        },
+        failedLibQcSamples() {
+            return this.sampleNames.filter(sample => this.sampleLibQcLabel(sample) === 'Fail');
         },
         countLabel() {
             return this.isHiseqX ? 'Clusters' : 'Reads';
@@ -224,6 +245,26 @@ const vReadsTotalComponent = {
             }
             return 'table-warning';
         },
+        sampleLibQcLabel(sample) {
+            const value = this.summaryRowLibQcMap[sample];
+            if (value === true || value === 'True' || value === 'true') {
+                return 'Pass';
+            }
+            if (value === false || value === 'False' || value === 'false') {
+                return 'Fail';
+            }
+            return '-';
+        },
+        sampleLibQcBadgeClass(sample) {
+            const value = this.summaryRowLibQcMap[sample];
+            if (value === true || value === 'True' || value === 'true') {
+                return 'badge bg-success rounded-pill';
+            }
+            if (value === false || value === 'False' || value === 'false') {
+                return 'badge bg-danger rounded-pill';
+            }
+            return 'badge bg-secondary rounded-pill';
+        },
         fcpFlowcellUrl(fcp) {
             const parts = fcp.split('_');
             const lastPart = parts[parts.length - 1].split(':')[0];
@@ -267,6 +308,19 @@ const vReadsTotalComponent = {
             const isChecked = event.target.checked;
             (this.readsData[sample] || []).forEach(d => {
                 this.checkedState[`${sample}_${d.fcp}`] = isChecked;
+            });
+        },
+        areSamplesFullyChecked(samples) {
+            if (samples.length === 0) return false;
+            return samples.every(sample => this.isSampleChecked(sample));
+        },
+        toggleSamplesByLibQc(label) {
+            const samples = label === 'Pass' ? this.passedLibQcSamples : this.failedLibQcSamples;
+            const nextValue = !this.areSamplesFullyChecked(samples);
+            samples.forEach(sample => {
+                (this.readsData[sample] || []).forEach(d => {
+                    this.checkedState[`${sample}_${d.fcp}`] = nextValue;
+                });
             });
         },
         formatQ30(value) {
@@ -435,6 +489,24 @@ const vReadsTotalComponent = {
                     <input type="button" class="btn btn-outline-secondary" :value="showBulkFlowcellEditor ? 'Hide bulk flowcell editor' : 'Bulk edit flowcells'" @click="toggleBulkFlowcellEditor"/>
                     <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
                 </div>
+                <div class="d-flex flex-wrap gap-2 mb-3">
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-outline-success rounded-pill"
+                        :disabled="passedLibQcSamples.length === 0"
+                        @click="toggleSamplesByLibQc('Pass')"
+                    >
+                        {{ areSamplesFullyChecked(passedLibQcSamples) ? 'Uncheck' : 'Check' }} Pass QC samples
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-outline-danger rounded-pill"
+                        :disabled="failedLibQcSamples.length === 0"
+                        @click="toggleSamplesByLibQc('Fail')"
+                    >
+                        {{ areSamplesFullyChecked(failedLibQcSamples) ? 'Uncheck' : 'Check' }} Fail QC samples
+                    </button>
+                </div>
                 <div v-if="showBulkFlowcellEditor" class="card mb-3">
                     <div class="card-body">
                         <div class="d-flex flex-wrap align-items-end gap-2 mb-3">
@@ -472,7 +544,8 @@ const vReadsTotalComponent = {
                             <tr class="darkth">
                                 <th style="position: sticky; top: 0; z-index: 2;">Include</th>
                                 <th style="position: sticky; top: 0; z-index: 2; cursor: pointer;" @click="setSort('sample')">Sample <span>{{ sortIndicator('sample') }}</span></th>
-                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">Flowcells</th>
+                                <th style="position: sticky; top: 0; z-index: 2; cursor: pointer;" @click="setSort('libQc')">Lib. QC <span>{{ sortIndicator('libQc') }}</span></th>
+                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums; cursor: pointer;" @click="setSort('flowcells')">Flowcells <span>{{ sortIndicator('flowcells') }}</span></th>
                                 <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums; cursor: pointer;" @click="setSort('reads')">{{ countLabel }} (selected) <span>{{ sortIndicator('reads') }}</span></th>
                                 <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums; cursor: pointer;" @click="setSort('q30')">Average % > q30 (selected) <span>{{ sortIndicator('q30') }}</span></th>
                             </tr>
@@ -496,12 +569,13 @@ const vReadsTotalComponent = {
                                         <span class="me-2" style="display: inline-block; font-size: 1.1rem; transition: transform 0.15s ease;" :style="{ transform: expandedSamples[sample] ? 'rotate(90deg)' : 'rotate(0deg)' }">▶</span>
                                         <a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)" @click.stop>{{ sample }}</a>
                                     </td>
+                                    <td><span :class="sampleLibQcBadgeClass(sample)">{{ sampleLibQcLabel(sample) }}</span></td>
                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ sampleFlowcellCount(sample) }}</td>
                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ summaryRowMap[sample].toLocaleString() }}</td>
                                     <td class="text-end" :class="sampleQ30Class(sample)" style="font-variant-numeric: tabular-nums;">{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
                                 </tr>
                                 <tr v-if="expandedSamples[sample]">
-                                    <td colspan="5" style="padding: 0 0 10px 30px;">
+                                    <td colspan="6" style="padding: 0 0 10px 30px;">
                                         <table class="table table-sm table-hover table-striped mb-0 align-middle">
                                             <thead>
                                                 <tr class="darkth">

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -111,6 +111,10 @@ const vReadsTotalComponent = {
             if (keys.length === 0) return false;
             return keys.every(key => this.checkedState[key]);
         },
+        areAllSamplesExpanded() {
+            if (this.sampleNames.length === 0) return false;
+            return this.sampleNames.every(sample => this.expandedSamples[sample]);
+        },
         countLabel() {
             return this.isHiseqX ? 'Clusters' : 'Reads';
         },
@@ -264,6 +268,15 @@ const vReadsTotalComponent = {
                 });
             });
         },
+        toggleAllSamplesExpanded() {
+            const nextValue = !this.areAllSamplesExpanded;
+            this.sampleNames.forEach(sample => {
+                this.expandedSamples[sample] = nextValue;
+            });
+        },
+        sampleFlowcellCount(sample) {
+            return (this.readsData[sample] || []).length;
+        },
         downloadMainTableTSV() {
             const rows = ['Sample\tReads\tQ30'];
             this.summaryRows.forEach(r => {
@@ -374,6 +387,7 @@ const vReadsTotalComponent = {
                 <div id="reads_total_summary_chart"></div>
                 <div class="btn-group mb-3" role="group">
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>
+                    <input type="button" class="btn btn-outline-secondary" :value="areAllSamplesExpanded ? 'Collapse all' : 'Expand all'" @click="toggleAllSamplesExpanded"/>
                     <input type="button" class="btn btn-outline-secondary" :value="showBulkFlowcellEditor ? 'Hide bulk flowcell editor' : 'Bulk edit flowcells'" @click="toggleBulkFlowcellEditor"/>
                     <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
                 </div>
@@ -409,20 +423,21 @@ const vReadsTotalComponent = {
                     </div>
                 </div>
                 <div class="container-fluid">
-                    <table class="table reads_table">
+                    <table class="table table-hover table-striped align-middle reads_table">
                         <thead>
                             <tr class="darkth">
-                                <th>Include</th>
-                                <th>Sample</th>
-                                <th>{{ countLabel }} (selected)</th>
-                                <th>Average % > q30 (selected)</th>
+                                <th style="position: sticky; top: 0; z-index: 2;">Include</th>
+                                <th style="position: sticky; top: 0; z-index: 2;">Sample</th>
+                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">Flowcells</th>
+                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">{{ countLabel }} (selected)</th>
+                                <th class="text-end" style="position: sticky; top: 0; z-index: 2; font-variant-numeric: tabular-nums;">Average % > q30 (selected)</th>
                             </tr>
                         </thead>
                         <tbody>
                             <template v-for="sample in sampleNames" :key="sample">
                                 <tr :id="sample" class="sample_table"
                                     :class="{ highlighted: highlightedSample === sample }"
-                                    style="cursor: pointer;"
+                                    style="cursor: pointer; transition: background-color 0.15s ease;"
                                     @click="toggleSampleExpanded(sample)">
                                     <td>
                                         <input
@@ -434,29 +449,30 @@ const vReadsTotalComponent = {
                                         />
                                     </td>
                                     <td>
-                                        <span class="me-2">{{ expandedSamples[sample] ? '▼' : '▶' }}</span>
+                                        <span class="me-2" style="display: inline-block; font-size: 1.1rem; transition: transform 0.15s ease;" :style="{ transform: expandedSamples[sample] ? 'rotate(90deg)' : 'rotate(0deg)' }">▶</span>
                                         <a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)" @click.stop>{{ sample }}</a>
                                     </td>
-                                    <td>{{ summaryRowMap[sample].toLocaleString() }}</td>
-                                    <td>{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
+                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ sampleFlowcellCount(sample) }}</td>
+                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ summaryRowMap[sample].toLocaleString() }}</td>
+                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
                                 </tr>
                                 <tr v-if="expandedSamples[sample]">
-                                    <td colspan="4" style="padding: 0 0 10px 30px;">
-                                        <table class="table table-sm mb-0">
+                                    <td colspan="5" style="padding: 0 0 10px 30px;">
+                                        <table class="table table-sm table-hover table-striped mb-0 align-middle">
                                             <thead>
                                                 <tr class="darkth">
                                                     <th>Include</th>
                                                     <th>Flowcell:Lane</th>
-                                                    <th>{{ countLabel }}</th>
-                                                    <th>% > q30</th>
+                                                    <th class="text-end" style="font-variant-numeric: tabular-nums;">{{ countLabel }}</th>
+                                                    <th class="text-end" style="font-variant-numeric: tabular-nums;">% > q30</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
                                                 <tr v-for="d in readsData[sample]" :key="d.fcp">
                                                     <td><input type="checkbox" v-model="checkedState[sample + '_' + d.fcp]"/></td>
                                                     <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
-                                                    <td>{{ d.cl }}</td>
-                                                    <td :class="q30Class(d)">{{ d.q30 }}</td>
+                                                    <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ d.cl }}</td>
+                                                    <td class="text-end" :class="q30Class(d)" style="font-variant-numeric: tabular-nums;">{{ d.q30 }}</td>
                                                 </tr>
                                             </tbody>
                                         </table>
@@ -468,8 +484,9 @@ const vReadsTotalComponent = {
                             <tr class="darkth">
                                 <th></th>
                                 <th></th>
-                                <th>Total selected</th>
-                                <th>{{ totalClusters.toLocaleString() }}</th>
+                                <th></th>
+                                <th class="text-end">Total selected</th>
+                                <th class="text-end" style="font-variant-numeric: tabular-nums;">{{ totalClusters.toLocaleString() }}</th>
                             </tr>
                         </tfoot>
                     </table>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -392,14 +392,6 @@ const vReadsTotalComponent = {
             const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/tab-separated-values;charset=utf-8' });
             saveAs(blob, `${this.query}_reads_total.tsv`);
         },
-        submitSearch() {
-            const val = this.$refs.queryInput.value.trim();
-            if (!val) {
-                alert('Error - search term cannot be empty');
-            } else {
-                location.href = '/reads_total/' + val;
-            }
-        },
         renderChart() {
             if (!this.hasData) return;
             if (this.chartInstance) {
@@ -463,20 +455,6 @@ const vReadsTotalComponent = {
     template: /*html*/`
         <div>
             <h1>Read Count Totals: <span>{{ query }}</span></h1>
-            <div id="querybox">
-                <form @submit.prevent="submitSearch">
-                    <div class="form-group">
-                        <label class="fw-bold" for="reads_query">Enter new search term here:</label>
-                        <div class="input-group" style="max-width: 400px;">
-                            <input type="text" class="form-control" id="reads_query" ref="queryInput" placeholder="eg. P1234">
-                            <span class="input-group-btn">
-                                <button class="btn btn-outline-secondary" type="submit">Search</button>
-                            </span>
-                        </div>
-                        <span class="form-text">Page finds any samples whose names begin with the search term.</span>
-                    </div>
-                </form>
-            </div>
         </div>
 
         <template v-if="loading && query">
@@ -489,15 +467,13 @@ const vReadsTotalComponent = {
             <div class="alert alert-danger mt-3">
                 <h4>Error</h4>
                 <p>{{ error }}</p>
-                <p>Please try again with the box above.</p>
+                <p>Please reload the page and try again.</p>
             </div>
         </template>
 
         <template v-else-if="query === ''">
-            <h3 class="mt-3">Welcome to the read count totals page!</h3>
-            <p>To begin, enter a search term above and click <code>Search</code></p>
-            <p>The search works by matching any sample names that begin with your search term. So P123 will match samples <code>P123_001</code> and <code>P1234_003</code></p>
-            <p>Note that sample names do not have full project names such as <code>A.Project_15_03</code>, so these kinds of searches will not work.</p>
+            <h3 class="mt-3">Read totals are now project-scoped.</h3>
+            <p>Open this view from a project page to load read totals for that project.</p>
         </template>
 
         <template v-else-if="hasData">
@@ -638,9 +614,7 @@ const vReadsTotalComponent = {
         <template v-else>
             <div class="alert alert-danger mt-3">
                 <h4>Error - No samples found</h4>
-                <p>Sorry, we weren't able to find any samples matching <code>{{ query }}</code>. Please try again with the box above.</p>
-                <p>The search works by matching any sample names that begin with your search term. So P123 will match samples <code>P123_001</code> and <code>P1234_003</code></p>
-                <p>Note that sample names do not have full project names such as <code>A.Project_15_03</code>, so these kinds of searches will not work.</p>
+                <p>Sorry, we weren't able to find any samples for <code>{{ query }}</code>.</p>
             </div>
         </template>
     `

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -498,6 +498,9 @@ const vReadsTotalComponent = {
         <template v-else-if="hasData">
             <div>
                 <div id="reads_total_summary_chart"></div>
+                <p v-if="expectedMinYieldPerSample !== null" class="text-muted small mb-3">
+                    Expected minimum yield / sample line = ordered lanes x 600M x 0.9 x 0.75 / number of project samples.
+                </p>
                 <div class="btn-group mb-3" role="group">
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>
                     <input type="button" class="btn btn-outline-secondary" :value="areAllSamplesExpanded ? 'Collapse all' : 'Expand all'" @click="toggleAllSamplesExpanded"/>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -211,7 +211,7 @@ const vReadsTotalComponent = {
                     this.checkedState = {};
                     for (const [sample, rows] of Object.entries(this.readsData)) {
                         for (const d of rows) {
-                            this.checkedState[`${sample}_${d.fcp}`] = this.isRowInitiallyChecked(d);
+                            this.checkedState[`${sample}_${d.fcp}`] = true;
                         }
                     }
                     this.expandedSamples = {};
@@ -219,6 +219,9 @@ const vReadsTotalComponent = {
                         this.expandedSamples[sample] = false;
                     });
                     this.bulkSelectedFlowcells = {};
+                    this.allFlowcellIds.forEach(id => {
+                        this.bulkSelectedFlowcells[id] = true;
+                    });
                     this.bulkFlowcellSearch = '';
                     this.showBulkFlowcellEditor = false;
                     
@@ -243,11 +246,7 @@ const vReadsTotalComponent = {
             return this.Q30_THRESHOLD_DICT[run_mode][run_setup];
         },
         isRowInitiallyChecked(d) {
-            if (d.fcp.includes('_UD')) return false;
-            const threshold = this.getRowThreshold(d);
-            return d.q30 !== null && d.q30 !== undefined &&
-                   parseFloat(d.q30) >= threshold &&
-                   (d.sample_status ?? '') !== 'Failed';
+            return true;
         },
         q30Class(d) {
             if (d.fcp.includes('_UD')) return '';

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -265,14 +265,10 @@ const vReadsTotalComponent = {
             });
         },
         downloadMainTableTSV() {
-            const rows = [`Sample\tFlowcell\tQ30\tSelected\t${this.countLabel}`];
-            this.sampleNames.forEach(sample => {
-                this.readsData[sample].forEach(d => {
-                    const selected = this.checkedState[`${sample}_${d.fcp}`] ? 'Yes' : 'No';
-                    const q30Value = d.q30 ?? '';
-                    const countValue = d.cl ?? '';
-                    rows.push(`${sample}\t${d.fcp}\t${q30Value}\t${selected}\t${countValue}`);
-                });
+            const rows = ['Sample\tReads\tQ30'];
+            this.summaryRows.forEach(r => {
+                const q30Value = r.avgQ30 === null ? '' : Number(r.avgQ30).toFixed(2);
+                rows.push(`${r.sample}\t${r.checkedReads}\t${q30Value}`);
             });
             const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/tab-separated-values;charset=utf-8' });
             saveAs(blob, `${this.query}_reads_total.tsv`);

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -16,6 +16,7 @@ const vReadsTotalComponent = {
             checkKeyFilter: '',
             highlightedSample: null,
             checkedState: {},
+            expandedSamples: {},
             chartInstance: null,
             loading: true,
             error: null,
@@ -29,39 +30,41 @@ const vReadsTotalComponent = {
         sampleNames() {
             return Object.keys(this.readsData).filter(k => k !== 'isHiseqX');
         },
-        sampleChunks() {
-            const chunks = [];
-            for (let i = 0; i < this.sampleNames.length; i += 2) {
-                chunks.push(this.sampleNames.slice(i, i + 2));
-            }
-            return chunks;
-        },
         summaryRows() {
             return this.sampleNames.map(sample => {
-                let checked = 0, unchecked = 0, w_q30_sum = 0;
+                let checkedReads = 0, uncheckedReads = 0, q30Sum = 0, checkedQ30Count = 0;
                 const rows = this.readsData[sample];
                 rows.forEach(d => {
                     const count = parseInt(d.cl) || 0;
                     if (this.checkedState[`${sample}_${d.fcp}`]) {
-                        w_q30_sum += (parseFloat(d.q30) || 0) * count;
-                        checked += count;
+                        checkedReads += count;
+                        const q30 = parseFloat(d.q30);
+                        if (!Number.isNaN(q30)) {
+                            q30Sum += q30;
+                            checkedQ30Count += 1;
+                        }
                     } else {
-                        unchecked += count;
+                        uncheckedReads += count;
                     }
                 });
-                const w_q30 = checked > 0 ? w_q30_sum / checked : -1;
+                const avgQ30 = checkedQ30Count > 0 ? q30Sum / checkedQ30Count : null;
                 const firstRow = rows.find(d => d.run_mode != null) || rows[0];
                 const threshold = firstRow ? this.getRowThreshold(firstRow) : 85.0;
-                return { sample, checked, unchecked, w_q30, threshold };
+                return { sample, checkedReads, uncheckedReads, avgQ30, threshold };
             });
         },
         summaryRowMap() {
             const map = {};
-            this.summaryRows.forEach(r => { map[r.sample] = r.checked; });
+            this.summaryRows.forEach(r => { map[r.sample] = r.checkedReads; });
+            return map;
+        },
+        summaryRowQ30Map() {
+            const map = {};
+            this.summaryRows.forEach(r => { map[r.sample] = r.avgQ30; });
             return map;
         },
         totalClusters() {
-            return this.summaryRows.reduce((sum, r) => sum + r.checked, 0);
+            return this.summaryRows.reduce((sum, r) => sum + r.checkedReads, 0);
         },
         countLabel() {
             return this.isHiseqX ? 'Clusters' : 'Reads';
@@ -97,6 +100,10 @@ const vReadsTotalComponent = {
                             this.checkedState[`${sample}_${d.fcp}`] = this.isRowInitiallyChecked(d);
                         }
                     }
+                    this.expandedSamples = {};
+                    this.sampleNames.forEach(sample => {
+                        this.expandedSamples[sample] = false;
+                    });
                     
                     this.loading = false;
                     this.$nextTick(() => this.renderChart());
@@ -155,6 +162,7 @@ const vReadsTotalComponent = {
         },
         highlightSample(sample) {
             this.highlightedSample = sample;
+            this.expandedSamples[sample] = true;
             this.$nextTick(() => {
                 const el = document.getElementById(sample);
                 if (el) {
@@ -162,6 +170,30 @@ const vReadsTotalComponent = {
                     location.hash = '#' + sample;
                 }
             });
+        },
+        toggleSampleExpanded(sample) {
+            this.expandedSamples[sample] = !this.expandedSamples[sample];
+        },
+        isSampleChecked(sample) {
+            const rows = this.readsData[sample] || [];
+            if (rows.length === 0) return false;
+            return rows.every(d => this.checkedState[`${sample}_${d.fcp}`]);
+        },
+        isSampleIndeterminate(sample) {
+            const rows = this.readsData[sample] || [];
+            if (rows.length === 0) return false;
+            const selectedCount = rows.filter(d => this.checkedState[`${sample}_${d.fcp}`]).length;
+            return selectedCount > 0 && selectedCount < rows.length;
+        },
+        onSampleCheckboxChange(sample, event) {
+            const isChecked = event.target.checked;
+            (this.readsData[sample] || []).forEach(d => {
+                this.checkedState[`${sample}_${d.fcp}`] = isChecked;
+            });
+        },
+        formatQ30(value) {
+            if (value === null || value === undefined) return '-';
+            return Number(value).toFixed(2);
         },
         downloadMainTableTSV() {
             const rows = [`Sample\tFlowcell\tQ30\tSelected\t${this.countLabel}`];
@@ -197,14 +229,14 @@ const vReadsTotalComponent = {
                 { name: 'Not Selected',  data: [], color: '#dddddd' }
             ];
             this.summaryRows.forEach(r => {
-                if (r.w_q30 >= r.threshold) {
-                    seriesData[0].data.push(r.checked);
+                if (r.avgQ30 !== null && r.avgQ30 >= r.threshold) {
+                    seriesData[0].data.push(r.checkedReads);
                     seriesData[1].data.push(0);
                 } else {
                     seriesData[0].data.push(0);
-                    seriesData[1].data.push(r.checked);
+                    seriesData[1].data.push(r.checkedReads);
                 }
-                seriesData[2].data.push(r.unchecked);
+                seriesData[2].data.push(r.uncheckedReads);
             });
             this.chartInstance = Highcharts.chart('reads_total_summary_chart', {
                 credits: { enabled: false },
@@ -214,7 +246,7 @@ const vReadsTotalComponent = {
                 xAxis: { categories: sampleNames },
                 yAxis: {
                     min: 0,
-                    title: { text: '# Clusters' },
+                    title: { text: '# ' + this.countLabel },
                     reversedStacks: false
                 },
                 plotOptions: {
@@ -282,41 +314,70 @@ const vReadsTotalComponent = {
                     <input type="text" class="form-control" v-model="checkKeyFilter"/>
                 </div>
                 <div class="container-fluid">
-                    <template v-for="(chunk, idx) in sampleChunks" :key="idx">
-                        <hr>
-                        <div class="row">
-                            <div v-for="sample in chunk" :key="sample" :id="sample"
-                                 class="col-lg-6 sample_table" :class="{ highlighted: highlightedSample === sample }"
-                                 style="padding-top: 15px;">
-                                <table class="table reads_table">
-                                    <thead>
-                                        <tr class="darkth">
-                                            <th><a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)">{{ sample }}</a></th>
-                                            <th>% > q30</th>
-                                            <th>Add</th>
-                                            <th>{{ countLabel }}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr v-for="d in readsData[sample]" :key="d.fcp">
-                                            <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
-                                            <td :class="q30Class(d)">{{ d.q30 }}</td>
-                                            <td><input type="checkbox" v-model="checkedState[sample + '_' + d.fcp]"/></td>
-                                            <td>{{ d.cl }}</td>
-                                        </tr>
-                                    </tbody>
-                                    <tfoot>
-                                        <tr class="darkth">
-                                            <th>Total</th>
-                                            <th></th>
-                                            <th>{{ sample }}</th>
-                                            <th>{{ summaryRowMap[sample].toLocaleString() }}</th>
-                                        </tr>
-                                    </tfoot>
-                                </table>
-                            </div>
-                        </div>
-                    </template>
+                    <table class="table reads_table">
+                        <thead>
+                            <tr class="darkth">
+                                <th>Sample</th>
+                                <th>Average % > q30 (selected)</th>
+                                <th>Add</th>
+                                <th>{{ countLabel }} (selected)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template v-for="sample in sampleNames" :key="sample">
+                                <tr :id="sample" class="sample_table"
+                                    :class="{ highlighted: highlightedSample === sample }"
+                                    style="cursor: pointer;"
+                                    @click="toggleSampleExpanded(sample)">
+                                    <td>
+                                        <span class="me-2">{{ expandedSamples[sample] ? '▼' : '▶' }}</span>
+                                        <a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)" @click.stop>{{ sample }}</a>
+                                    </td>
+                                    <td>{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
+                                    <td>
+                                        <input
+                                            type="checkbox"
+                                            :checked="isSampleChecked(sample)"
+                                            :indeterminate.prop="isSampleIndeterminate(sample)"
+                                            @click.stop
+                                            @change="onSampleCheckboxChange(sample, $event)"
+                                        />
+                                    </td>
+                                    <td>{{ summaryRowMap[sample].toLocaleString() }}</td>
+                                </tr>
+                                <tr v-if="expandedSamples[sample]">
+                                    <td colspan="4" style="padding: 0 0 10px 30px;">
+                                        <table class="table table-sm mb-0">
+                                            <thead>
+                                                <tr class="darkth">
+                                                    <th>Flowcell/Lane</th>
+                                                    <th>% > q30</th>
+                                                    <th>Add</th>
+                                                    <th>{{ countLabel }}</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr v-for="d in readsData[sample]" :key="d.fcp">
+                                                    <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
+                                                    <td :class="q30Class(d)">{{ d.q30 }}</td>
+                                                    <td><input type="checkbox" v-model="checkedState[sample + '_' + d.fcp]"/></td>
+                                                    <td>{{ d.cl }}</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </template>
+                        </tbody>
+                        <tfoot>
+                            <tr class="darkth">
+                                <th>Total selected</th>
+                                <th></th>
+                                <th></th>
+                                <th>{{ totalClusters.toLocaleString() }}</th>
+                            </tr>
+                        </tfoot>
+                    </table>
                 </div>
             </div>
         </template>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -522,8 +522,8 @@ const vReadsTotalComponent = {
                         </div>
                     </div>
                 </div>
-                <div class="container-fluid">
-                    <table class="table table-hover table-striped align-middle reads_table">
+                <div class="container-fluid table-responsive mt-4">
+                    <table class="table table-striped table-bordered align-middle reads_table mb-0">
                         <thead>
                             <tr class="darkth">
                                 <th style="position: sticky; top: 0; z-index: 2;">Include</th>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -6,7 +6,7 @@ const vReadsTotalComponent = {
     props: ['query'],
     data() {
         return {
-            THRESHOLD_DICT: {
+            Q30_THRESHOLD_DICT: {
                 'HiSeq X': { 'default': 75.0 },
                 'MiSeq': { '250': 60.0, '150': 70.0, '100': 75.0, 'default': 80.0 },
                 'default': { '250': 60.0, '150': 75.0, '100': 80.0, 'default': 85.0 }
@@ -223,7 +223,7 @@ const vReadsTotalComponent = {
                 else if (d.longer_read_length >= 150) run_setup = '150';
                 else if (d.longer_read_length >= 100) run_setup = '100';
             }
-            return this.THRESHOLD_DICT[run_mode][run_setup];
+            return this.Q30_THRESHOLD_DICT[run_mode][run_setup];
         },
         isRowInitiallyChecked(d) {
             if (d.fcp.includes('_UD')) return false;

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -537,7 +537,7 @@ const vReadsTotalComponent = {
                         <tbody>
                             <template v-for="sample in sortedSampleNames" :key="sample">
                                 <tr :id="sample" class="sample_table"
-                                    :class="{ highlighted: highlightedSample === sample }"
+                                    :class="{ highlighted: highlightedSample === sample, 'table-secondary': !isSampleChecked(sample) }"
                                     style="cursor: pointer; transition: background-color 0.15s ease;"
                                     @click="toggleSampleExpanded(sample)">
                                     <td>
@@ -570,7 +570,7 @@ const vReadsTotalComponent = {
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                                <tr v-for="d in sampleRows(sample)" :key="d.fcp">
+                                                <tr v-for="d in sampleRows(sample)" :key="d.fcp" :class="{ 'table-secondary': !checkedState[selectionKey(sample, d.fcp)] }">
                                                     <td><input type="checkbox" v-model="checkedState[selectionKey(sample, d.fcp)]"/></td>
                                                     <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
                                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ Number(d.cl).toLocaleString() }}</td>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -14,8 +14,7 @@ const vReadsTotalComponent = {
             readsData: {},
             isHiseqX: false,
             expectedMinYieldPerSample: null,
-            showBulkFlowcellEditor: false,
-            bulkFlowcellSearch: '',
+            showFlowcellSelection: false,
             bulkSelectedFlowcells: {},
             highlightedSample: null,
             checkedState: {},
@@ -113,11 +112,6 @@ const vReadsTotalComponent = {
                 });
             });
             return Array.from(ids).sort();
-        },
-        filteredFlowcellIds() {
-            const filter = this.bulkFlowcellSearch.trim().toLowerCase();
-            if (!filter) return this.allFlowcellIds;
-            return this.allFlowcellIds.filter(id => id.toLowerCase().includes(filter));
         },
         selectedFlowcellIds() {
             return this.allFlowcellIds.filter(id => this.bulkSelectedFlowcells[id]);
@@ -222,8 +216,7 @@ const vReadsTotalComponent = {
                     this.allFlowcellIds.forEach(id => {
                         this.bulkSelectedFlowcells[id] = true;
                     });
-                    this.bulkFlowcellSearch = '';
-                    this.showBulkFlowcellEditor = false;
+                    this.showFlowcellSelection = false;
                     
                     this.loading = false;
                     this.$nextTick(() => this.renderChart());
@@ -351,21 +344,8 @@ const vReadsTotalComponent = {
             if (value === null || value === undefined) return '-';
             return Number(value).toFixed(2);
         },
-        toggleBulkFlowcellEditor() {
-            this.showBulkFlowcellEditor = !this.showBulkFlowcellEditor;
-        },
-        selectVisibleFlowcells() {
-            this.filteredFlowcellIds.forEach(id => {
-                this.bulkSelectedFlowcells[id] = true;
-            });
-        },
-        clearVisibleFlowcells() {
-            this.filteredFlowcellIds.forEach(id => {
-                this.bulkSelectedFlowcells[id] = false;
-            });
-        },
-        clearAllBulkSelections() {
-            this.bulkSelectedFlowcells = {};
+        toggleFlowcellSelection() {
+            this.showFlowcellSelection = !this.showFlowcellSelection;
         },
         applyBulkFlowcellSelection(isChecked) {
             const selectedSet = this.selectedFlowcellIdSet;
@@ -502,7 +482,7 @@ const vReadsTotalComponent = {
                 <div class="btn-group mb-3" role="group">
                     <input type="button" class="btn btn-outline-secondary" :value="isAllSelected ? 'Uncheck all' : 'Check all'" @click="toggleAllSelection"/>
                     <input type="button" class="btn btn-outline-secondary" :value="areAllSamplesExpanded ? 'Collapse all' : 'Expand all'" @click="toggleAllSamplesExpanded"/>
-                    <input type="button" class="btn btn-outline-secondary" :value="showBulkFlowcellEditor ? 'Hide bulk flowcell editor' : 'Bulk edit flowcells'" @click="toggleBulkFlowcellEditor"/>
+                    <input type="button" class="btn btn-outline-secondary" :value="showFlowcellSelection ? 'Hide flowcell selection' : 'Select flowcells'" @click="toggleFlowcellSelection"/>
                     <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
                 </div>
                 <div class="d-flex flex-wrap gap-2 mb-3">
@@ -523,26 +503,14 @@ const vReadsTotalComponent = {
                         {{ areSamplesFullyChecked(failedLibQcSamples) ? 'Uncheck' : 'Check' }} Fail QC samples
                     </button>
                 </div>
-                <div v-if="showBulkFlowcellEditor" class="card mb-3">
+                <div v-if="showFlowcellSelection" class="card mb-3">
                     <div class="card-body">
-                        <div class="d-flex flex-wrap align-items-end gap-2 mb-3">
-                            <div style="min-width: 260px;">
-                                <label class="form-label fw-bold" for="bulk_flowcell_search">Find flowcell or lane</label>
-                                <input id="bulk_flowcell_search" type="text" class="form-control" v-model="bulkFlowcellSearch" placeholder="Search IDs"/>
-                            </div>
-                            <input type="button" class="btn btn-outline-secondary" value="Select visible" @click="selectVisibleFlowcells"/>
-                            <input type="button" class="btn btn-outline-secondary" value="Clear visible" @click="clearVisibleFlowcells"/>
-                            <input type="button" class="btn btn-outline-secondary" value="Clear selected IDs" @click="clearAllBulkSelections"/>
-                        </div>
-
                         <p class="mb-2">
-                            Selected IDs: {{ selectedFlowcellIds.length }}.
-                            Matching rows: {{ bulkAffectedRowsCount }} across {{ bulkAffectedSamplesCount }} samples.
+                            Select one or more flowcells below, then apply the change across all samples.
                         </p>
 
                         <div style="max-height: 220px; overflow: auto; border: 1px solid #d9d9d9; border-radius: 4px; padding: 8px;">
-                            <div v-if="filteredFlowcellIds.length === 0" class="text-muted">No flowcell/lane IDs match this search.</div>
-                            <div v-for="id in filteredFlowcellIds" :key="id" class="form-check">
+                            <div v-for="id in allFlowcellIds" :key="id" class="form-check">
                                 <input class="form-check-input" type="checkbox" :id="'bulk_' + id" v-model="bulkSelectedFlowcells[id]"/>
                                 <label class="form-check-label" :for="'bulk_' + id">{{ id }}</label>
                             </div>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -163,14 +163,18 @@ const vReadsTotalComponent = {
                 }
             });
         },
-        downloadSummary() {
-            let text = `Sample\t${this.countLabel}\n`;
-            this.summaryRows.forEach(r => {
-                text += `${r.sample}\t${r.checked}\n`;
+        downloadMainTableTSV() {
+            const rows = [`Sample\tFlowcell\tQ30\tSelected\t${this.countLabel}`];
+            this.sampleNames.forEach(sample => {
+                this.readsData[sample].forEach(d => {
+                    const selected = this.checkedState[`${sample}_${d.fcp}`] ? 'Yes' : 'No';
+                    const q30Value = d.q30 ?? '';
+                    const countValue = d.cl ?? '';
+                    rows.push(`${sample}\t${d.fcp}\t${q30Value}\t${selected}\t${countValue}`);
+                });
             });
-            text += `Total (${this.summaryRows.length} samples)\t${this.totalClusters}\n`;
-            const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
-            saveAs(blob, `${this.query}_reads_total.txt`);
+            const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/tab-separated-values;charset=utf-8' });
+            saveAs(blob, `${this.query}_reads_total.tsv`);
         },
         submitSearch() {
             const val = this.$refs.queryInput.value.trim();
@@ -229,7 +233,7 @@ const vReadsTotalComponent = {
         }
     },
     template: /*html*/`
-        <div :style="hasData ? 'margin-left: 270px;' : ''">
+        <div>
             <h1>Read Count Totals: <span>{{ query }}</span></h1>
             <div id="querybox">
                 <form @submit.prevent="submitSearch">
@@ -269,35 +273,12 @@ const vReadsTotalComponent = {
         </template>
 
         <template v-else-if="hasData">
-            <!-- Fixed sidebar -->
-            <div style="width: 250px; position: fixed; left: 10px; top: 65px; height: 90%; overflow: auto;">
-                <h3>Summary of Selected {{ countLabel }} Counts</h3>
-                <p><button class="btn btn-outline-secondary" @click="downloadSummary">Download as tab-delimited file</button></p>
-                <table class="table table-hover">
-                    <thead>
-                        <tr class="darkth"><th>Sample</th><th>{{ countLabel }}</th></tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="row in summaryRows" :key="row.sample">
-                            <td><a href="#" @click.prevent="highlightSample(row.sample)" class="text-decoration-none">{{ row.sample }}</a></td>
-                            <td class="text-right">{{ row.checked.toLocaleString() }}</td>
-                        </tr>
-                    </tbody>
-                    <tfoot>
-                        <tr class="darkth">
-                            <th>Total ({{ summaryRows.length }} samples)</th>
-                            <th class="text-right">{{ totalClusters.toLocaleString() }}</th>
-                        </tr>
-                    </tfoot>
-                </table>
-            </div>
-
-            <!-- Main content -->
-            <div style="margin-left: 270px;">
+            <div>
                 <div id="reads_total_summary_chart"></div>
                 <div class="btn-group mb-3" role="group">
                     <input type="button" class="btn btn-outline-secondary" value="Check all" @click="checkAll"/>
                     <input type="button" class="btn btn-outline-secondary" value="Uncheck all" @click="uncheckAll"/>
+                    <input type="button" class="btn btn-outline-secondary" value="Download main table as TSV" @click="downloadMainTableTSV"/>
                     <input type="text" class="form-control" v-model="checkKeyFilter"/>
                 </div>
                 <div class="container-fluid">

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -412,10 +412,10 @@ const vReadsTotalComponent = {
                     <table class="table reads_table">
                         <thead>
                             <tr class="darkth">
+                                <th>Include</th>
                                 <th>Sample</th>
-                                <th>Average % > q30 (selected)</th>
-                                <th>Add</th>
                                 <th>{{ countLabel }} (selected)</th>
+                                <th>Average % > q30 (selected)</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -425,11 +425,6 @@ const vReadsTotalComponent = {
                                     style="cursor: pointer;"
                                     @click="toggleSampleExpanded(sample)">
                                     <td>
-                                        <span class="me-2">{{ expandedSamples[sample] ? '▼' : '▶' }}</span>
-                                        <a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)" @click.stop>{{ sample }}</a>
-                                    </td>
-                                    <td>{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
-                                    <td>
                                         <input
                                             type="checkbox"
                                             :checked="isSampleChecked(sample)"
@@ -438,25 +433,30 @@ const vReadsTotalComponent = {
                                             @change="onSampleCheckboxChange(sample, $event)"
                                         />
                                     </td>
+                                    <td>
+                                        <span class="me-2">{{ expandedSamples[sample] ? '▼' : '▶' }}</span>
+                                        <a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)" @click.stop>{{ sample }}</a>
+                                    </td>
                                     <td>{{ summaryRowMap[sample].toLocaleString() }}</td>
+                                    <td>{{ formatQ30(summaryRowQ30Map[sample]) }}</td>
                                 </tr>
                                 <tr v-if="expandedSamples[sample]">
                                     <td colspan="4" style="padding: 0 0 10px 30px;">
                                         <table class="table table-sm mb-0">
                                             <thead>
                                                 <tr class="darkth">
-                                                    <th>Flowcell/Lane</th>
-                                                    <th>% > q30</th>
-                                                    <th>Add</th>
+                                                    <th>Include</th>
+                                                    <th>Flowcell:Lane</th>
                                                     <th>{{ countLabel }}</th>
+                                                    <th>% > q30</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
                                                 <tr v-for="d in readsData[sample]" :key="d.fcp">
-                                                    <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
-                                                    <td :class="q30Class(d)">{{ d.q30 }}</td>
                                                     <td><input type="checkbox" v-model="checkedState[sample + '_' + d.fcp]"/></td>
+                                                    <td><a class="text-decoration-none" :href="fcpFlowcellUrl(d.fcp)">{{ d.fcp }}</a></td>
                                                     <td>{{ d.cl }}</td>
+                                                    <td :class="q30Class(d)">{{ d.q30 }}</td>
                                                 </tr>
                                             </tbody>
                                         </table>
@@ -466,9 +466,9 @@ const vReadsTotalComponent = {
                         </tbody>
                         <tfoot>
                             <tr class="darkth">
+                                <th></th>
+                                <th></th>
                                 <th>Total selected</th>
-                                <th></th>
-                                <th></th>
                                 <th>{{ totalClusters.toLocaleString() }}</th>
                             </tr>
                         </tfoot>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -13,6 +13,7 @@ const vReadsTotalComponent = {
             },
             readsData: {},
             isHiseqX: false,
+            expectedMinYieldPerSample: null,
             showBulkFlowcellEditor: false,
             bulkFlowcellSearch: '',
             bulkSelectedFlowcells: {},
@@ -32,7 +33,7 @@ const vReadsTotalComponent = {
             return this.sampleNames.length > 0;
         },
         sampleNames() {
-            return Object.keys(this.readsData).filter(k => k !== 'isHiseqX');
+            return Object.keys(this.readsData).filter(k => Array.isArray(this.readsData[k]));
         },
         summaryRows() {
             return this.sampleNames.map(sample => {
@@ -184,7 +185,9 @@ const vReadsTotalComponent = {
                 .then(response => {
                     const data = response.data;
                     this.isHiseqX = data.isHiseqX || false;
+                    this.expectedMinYieldPerSample = data.expectedMinYieldPerSample ?? null;
                     delete data.isHiseqX;
+                    delete data.expectedMinYieldPerSample;
                     this.readsData = data;
                     
                     // Initialize checkbox state
@@ -423,7 +426,19 @@ const vReadsTotalComponent = {
                 yAxis: {
                     min: 0,
                     title: { text: '# ' + this.countLabel },
-                    reversedStacks: false
+                    reversedStacks: false,
+                    plotLines: this.expectedMinYieldPerSample !== null ? [{
+                        color: '#fd0d0d',
+                        dashStyle: 'ShortDash',
+                        value: this.expectedMinYieldPerSample,
+                        width: 2,
+                        zIndex: 5,
+                        label: {
+                            text: 'Expected minimum yield / sample',
+                            align: 'right',
+                            style: { color: '#fd0d0d' }
+                        }
+                    }] : []
                 },
                 plotOptions: {
                     column: { stacking: 'normal', borderWidth: 0, groupPadding: 0.1 },

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -567,7 +567,7 @@ const vReadsTotalComponent = {
                                     </td>
                                     <td>
                                         <span class="me-2" style="display: inline-block; font-size: 1.1rem; transition: transform 0.15s ease;" :style="{ transform: expandedSamples[sample] ? 'rotate(90deg)' : 'rotate(0deg)' }">▶</span>
-                                        <a class="text-decoration-none" :href="'/project/' + projectFromSample(sample)" @click.stop>{{ sample }}</a>
+                                        <span>{{ sample }}</span>
                                     </td>
                                     <td><span :class="sampleLibQcBadgeClass(sample)">{{ sampleLibQcLabel(sample) }}</span></td>
                                     <td class="text-end" style="font-variant-numeric: tabular-nums;">{{ sampleFlowcellCount(sample) }}</td>

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -882,9 +882,47 @@ class ReadsTotalDataHandler(SafeHandler):
                     if row["key"][1] + ":" + row["key"][2] == fcl["fcp"]:
                         fcl["sample_status"] = row["value"]["sample_status"]
                         break  # since the row is already found
+
+        project_ids = {sample.split("_")[0] for sample in data.keys() if "_" in sample}
+        if project_ids:
+            sample_view_rows = app.cloudant.post_view(
+                db="projects",
+                ddoc="project",
+                view="samples",
+                keys=list(project_ids),
+            ).get_result()["rows"]
+
+            samples_by_project = {
+                row["key"]: row.get("value") or {} for row in sample_view_rows
+            }
+
+            for sample_name, sample_rows in data.items():
+                project_id = sample_name.split("_")[0]
+                sample_data = samples_by_project.get(project_id, {}).get(
+                    sample_name, {}
+                )
+                lib_qc_status = ReadsTotalDataHandler._sample_passed_library_qc(
+                    sample_data
+                )
+                for sample_row in sample_rows:
+                    sample_row["lib_qc"] = lib_qc_status
+
         for key in sorted(data.keys()):
             ordereddata[key] = sorted(data[key], key=lambda d: d["fcp"])
         return ordereddata
+
+    @staticmethod
+    def _sample_passed_library_qc(sample_data):
+        if not sample_data:
+            return "-"
+
+        if "passed_library_qc" in sample_data:
+            return sample_data["passed_library_qc"]
+
+        if "details" in sample_data and "passed_library_qc" in sample_data["details"]:
+            return sample_data["details"]["passed_library_qc"]
+
+        return "-"
 
 
 # Functions

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -840,6 +840,8 @@ class ReadsTotalDataHandler(SafeHandler):
     def get_total_reads(app, query):
         data = {}
         ordereddata = OrderedDict()
+        sample_start_key = f"{query}_"
+        sample_end_key = f"{query}_Z"
 
         # Get all flowcell info at once instead of per-row
         fc_info_view = app.cloudant.post_view(
@@ -854,8 +856,8 @@ class ReadsTotalDataHandler(SafeHandler):
             db="x_flowcells",
             ddoc="samples",
             view="lane_clusters",
-            start_key=query,
-            end_key=f"{query}Z",
+            start_key=sample_start_key,
+            end_key=sample_end_key,
             reduce=False,
         ).get_result()["rows"]
 
@@ -878,8 +880,8 @@ class ReadsTotalDataHandler(SafeHandler):
             db="bioinfo_analysis",
             ddoc="latest_data",
             view="sample_id",
-            start_key=[query, None, None, None],
-            end_key=[f"{query}Z", "ZZ", "ZZ", "ZZ"],
+            start_key=[sample_start_key, None, None, None],
+            end_key=[sample_end_key, "ZZ", "ZZ", "ZZ"],
         ).get_result()["rows"]
         for row in bioinfo_view:
             if row["key"][3] in data:

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -809,6 +809,10 @@ class ReadsTotalDataHandler(SafeHandler):
     Returns JSON with reads data for the given query
     """
 
+    UNIT_YIELD = 600_000_000
+    FLOWCELL_YIELD_FACTOR = 0.9
+    SAMPLE_YIELD_FACTOR = 0.75
+
     def get(self, query):
         if not query:
             data = {}
@@ -820,12 +824,11 @@ class ReadsTotalDataHandler(SafeHandler):
             )
 
         # Check if any data is HiSeq X to mark in response
-        is_hiseq_x = False
-        for sample_rows in data.values():
-            for row in sample_rows:
-                if row.get("run_mode") == "HiSeq X":
-                    is_hiseq_x = True
-                    break
+        is_hiseq_x = any(
+            row.get("run_mode") == "HiSeq X"
+            for sample_rows in data.values()
+            for row in sample_rows
+        )
 
         data["isHiseqX"] = is_hiseq_x
         data["expectedMinYieldPerSample"] = expected_min_yield_per_sample
@@ -839,16 +842,13 @@ class ReadsTotalDataHandler(SafeHandler):
         ordereddata = OrderedDict()
 
         # Get all flowcell info at once instead of per-row
-        fc_info_cache = {}
         fc_info_view = app.cloudant.post_view(
             db="x_flowcells",
             ddoc="info",
             view="summary",
             descending=True,
         ).get_result()["rows"]
-
-        for row in fc_info_view:
-            fc_info_cache[row["key"]] = row["value"]
+        fc_info_cache = {row["key"]: row["value"] for row in fc_info_view}
 
         xfc_view = app.cloudant.post_view(
             db="x_flowcells",
@@ -888,7 +888,12 @@ class ReadsTotalDataHandler(SafeHandler):
                         fcl["sample_status"] = row["value"]["sample_status"]
                         break  # since the row is already found
 
-        project_ids = {sample.split("_")[0] for sample in data.keys() if "_" in sample}
+        project_ids = {
+            project_id
+            for sample in data.keys()
+            for project_id in [ReadsTotalDataHandler._project_id_from_sample(sample)]
+            if project_id
+        }
         if project_ids:
             sample_view_rows = app.cloudant.post_view(
                 db="projects",
@@ -902,7 +907,9 @@ class ReadsTotalDataHandler(SafeHandler):
             }
 
             for sample_name, sample_rows in data.items():
-                project_id = sample_name.split("_")[0]
+                project_id = ReadsTotalDataHandler._project_id_from_sample(sample_name)
+                if not project_id:
+                    continue
                 sample_data = samples_by_project.get(project_id, {}).get(
                     sample_name, {}
                 )
@@ -946,8 +953,19 @@ class ReadsTotalDataHandler(SafeHandler):
         return None
 
     @staticmethod
+    def _project_id_from_sample(sample_name):
+        if "_" not in sample_name:
+            return None
+        return sample_name.split("_", 1)[0]
+
+    @staticmethod
     def get_expected_min_yield_per_sample(app, sample_names):
-        project_ids = {sample.split("_")[0] for sample in sample_names if "_" in sample}
+        project_ids = {
+            project_id
+            for sample in sample_names
+            for project_id in [ReadsTotalDataHandler._project_id_from_sample(sample)]
+            if project_id
+        }
         if len(project_ids) != 1:
             return None
 
@@ -983,7 +1001,13 @@ class ReadsTotalDataHandler(SafeHandler):
         if total_samples == 0:
             return None
 
-        return units_ordered * 600_000_000 * 0.9 / total_samples * 0.75
+        return (
+            units_ordered
+            * ReadsTotalDataHandler.UNIT_YIELD
+            * ReadsTotalDataHandler.FLOWCELL_YIELD_FACTOR
+            / total_samples
+            * ReadsTotalDataHandler.SAMPLE_YIELD_FACTOR
+        )
 
 
 # Functions

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -890,36 +890,23 @@ class ReadsTotalDataHandler(SafeHandler):
                         fcl["sample_status"] = row["value"]["sample_status"]
                         break  # since the row is already found
 
-        project_ids = {
-            project_id
-            for sample in data.keys()
-            for project_id in [ReadsTotalDataHandler._project_id_from_sample(sample)]
-            if project_id
+        sample_view_rows = app.cloudant.post_view(
+            db="projects",
+            ddoc="project",
+            view="samples",
+            key=query,
+        ).get_result()["rows"]
+
+        samples_by_project = {
+            row["key"]: row.get("value") or {} for row in sample_view_rows
         }
-        if project_ids:
-            sample_view_rows = app.cloudant.post_view(
-                db="projects",
-                ddoc="project",
-                view="samples",
-                keys=list(project_ids),
-            ).get_result()["rows"]
+        project_sample_data = samples_by_project.get(query, {})
 
-            samples_by_project = {
-                row["key"]: row.get("value") or {} for row in sample_view_rows
-            }
-
-            for sample_name, sample_rows in data.items():
-                project_id = ReadsTotalDataHandler._project_id_from_sample(sample_name)
-                if not project_id:
-                    continue
-                sample_data = samples_by_project.get(project_id, {}).get(
-                    sample_name, {}
-                )
-                lib_qc_status = ReadsTotalDataHandler._sample_passed_library_qc(
-                    sample_data
-                )
-                for sample_row in sample_rows:
-                    sample_row["lib_qc"] = lib_qc_status
+        for sample_name, sample_rows in data.items():
+            sample_data = project_sample_data.get(sample_name, {})
+            lib_qc_status = ReadsTotalDataHandler._sample_passed_library_qc(sample_data)
+            for sample_row in sample_rows:
+                sample_row["lib_qc"] = lib_qc_status
 
         for key in sorted(data.keys()):
             ordereddata[key] = sorted(data[key], key=lambda d: d["fcp"])
@@ -955,23 +942,11 @@ class ReadsTotalDataHandler(SafeHandler):
         return None
 
     @staticmethod
-    def _project_id_from_sample(sample_name):
-        if "_" not in sample_name:
-            return None
-        return sample_name.split("_", 1)[0]
-
-    @staticmethod
     def get_expected_min_yield_per_sample(app, sample_names):
-        project_ids = {
-            project_id
-            for sample in sample_names
-            for project_id in [ReadsTotalDataHandler._project_id_from_sample(sample)]
-            if project_id
-        }
-        if len(project_ids) != 1:
+        if not sample_names:
             return None
 
-        project_id = next(iter(project_ids))
+        project_id = sample_names[0].split("_", 1)[0]
 
         project_rows = app.cloudant.post_view(
             db="projects",

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -820,7 +820,7 @@ class ReadsTotalDataHandler(SafeHandler):
         else:
             data = self.get_total_reads(self.application, query)
             expected_min_yield_per_sample = self.get_expected_min_yield_per_sample(
-                self.application, query,list(data.keys())
+                self.application, query, list(data.keys())
             )
 
         # Check if any data is HiSeq X to mark in response
@@ -954,6 +954,10 @@ class ReadsTotalDataHandler(SafeHandler):
             return None
 
         details = project_rows[0].get("doc", {}).get("details", {})
+        flowcell_type = str(details.get("flowcell", "")).strip()
+        if not flowcell_type.startswith("Universal-"):
+            return None
+
         units_ordered = ReadsTotalDataHandler._parse_units_ordered(
             details.get("sequence_units_ordered_(lanes)")
         )

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -819,8 +819,20 @@ class ReadsTotalDataHandler(SafeHandler):
             expected_min_yield_per_sample = None
         else:
             data = self.get_total_reads(self.application, query)
+            project_run_mode = None
+            for sample_rows in data.values():
+                for row in sample_rows:
+                    run_mode = row.get("run_mode")
+                    if run_mode:
+                        project_run_mode = run_mode
+                        break
+                if project_run_mode:
+                    break
             expected_min_yield_per_sample = self.get_expected_min_yield_per_sample(
-                self.application, query, list(data.keys())
+                self.application,
+                query,
+                list(data.keys()),
+                project_run_mode=project_run_mode,
             )
 
         # Check if any data is HiSeq X to mark in response
@@ -939,7 +951,9 @@ class ReadsTotalDataHandler(SafeHandler):
         return None
 
     @staticmethod
-    def get_expected_min_yield_per_sample(app, query, sample_names):
+    def get_expected_min_yield_per_sample(
+        app, query, sample_names, project_run_mode=None
+    ):
         if not sample_names:
             return None
 
@@ -955,14 +969,6 @@ class ReadsTotalDataHandler(SafeHandler):
 
         details = project_rows[0].get("doc", {}).get("details", {})
         flowcell_type = str(details.get("flowcell", "")).strip()
-        if not flowcell_type.startswith("Universal-"):
-            return None
-
-        units_ordered = ReadsTotalDataHandler._parse_units_ordered(
-            details.get("sequence_units_ordered_(lanes)")
-        )
-        if units_ordered is None:
-            return None
 
         sample_rows = app.cloudant.post_view(
             db="projects",
@@ -977,9 +983,51 @@ class ReadsTotalDataHandler(SafeHandler):
         if total_samples == 0:
             return None
 
+        if flowcell_type.startswith("Universal-"):
+            units_ordered = ReadsTotalDataHandler._parse_units_ordered(
+                details.get("sequence_units_ordered_(lanes)")
+            )
+            if units_ordered is None:
+                return None
+
+            return (
+                units_ordered
+                * ReadsTotalDataHandler.UNIT_YIELD
+                * ReadsTotalDataHandler.FLOWCELL_YIELD_FACTOR
+                / total_samples
+                * ReadsTotalDataHandler.SAMPLE_YIELD_FACTOR
+            )
+
+        # Prefer the run mode already loaded with the per-sample flowcell rows.
+        run_mode = str(project_run_mode or "").strip()
+        if not run_mode:
+            # Fallback for projects where the run_mode was not attached to the rows.
+            flowcell_name = str(
+                details.get("flowcell_id") or details.get("flowcell") or ""
+            ).strip()
+            if not flowcell_name:
+                return None
+
+            flowcell_rows = app.cloudant.post_view(
+                db="x_flowcells",
+                ddoc="info",
+                view="summary2_full_id",
+                key=flowcell_name,
+            ).get_result()["rows"]
+            if not flowcell_rows:
+                return None
+
+            run_mode = str(
+                flowcell_rows[0].get("value", {}).get("run_mode", "")
+            ).strip()
+
+        lane_threshold = thresholds.get(run_mode, 0)
+        if lane_threshold <= 0:
+            return None
+
         return (
-            units_ordered
-            * ReadsTotalDataHandler.UNIT_YIELD
+            lane_threshold
+            * 1_000_000
             * ReadsTotalDataHandler.FLOWCELL_YIELD_FACTOR
             / total_samples
             * ReadsTotalDataHandler.SAMPLE_YIELD_FACTOR

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -917,9 +917,6 @@ class ReadsTotalDataHandler(SafeHandler):
         if not sample_data:
             return "-"
 
-        if "passed_library_qc" in sample_data:
-            return sample_data["passed_library_qc"]
-
         if "details" in sample_data and "passed_library_qc" in sample_data["details"]:
             return sample_data["details"]["passed_library_qc"]
 

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -817,6 +817,7 @@ class ReadTotalsDataHandler(SafeHandler):
         if not query:
             data = {}
             expected_min_yield_per_sample = None
+            expected_min_yield_formula_mode = None
         else:
             data = self.get_total_reads(self.application, query)
             project_run_mode = None
@@ -828,7 +829,10 @@ class ReadTotalsDataHandler(SafeHandler):
                         break
                 if project_run_mode:
                     break
-            expected_min_yield_per_sample = self.get_expected_min_yield_per_sample(
+            (
+                expected_min_yield_per_sample,
+                expected_min_yield_formula_mode,
+            ) = self.get_expected_min_yield_per_sample(
                 self.application,
                 query,
                 list(data.keys()),
@@ -844,6 +848,7 @@ class ReadTotalsDataHandler(SafeHandler):
 
         data["isHiseqX"] = is_hiseq_x
         data["expectedMinYieldPerSample"] = expected_min_yield_per_sample
+        data["expectedMinYieldFormulaMode"] = expected_min_yield_formula_mode
 
         self.set_header("Content-type", "application/json")
         self.write(json.dumps(data))
@@ -955,7 +960,7 @@ class ReadTotalsDataHandler(SafeHandler):
         app, query, sample_names, project_run_mode=None
     ):
         if not sample_names:
-            return None
+            return None, None
 
         project_rows = app.cloudant.post_view(
             db="projects",
@@ -965,7 +970,7 @@ class ReadTotalsDataHandler(SafeHandler):
             include_docs=True,
         ).get_result()["rows"]
         if not project_rows:
-            return None
+            return None, None
 
         details = project_rows[0].get("doc", {}).get("details", {})
         flowcell_type = str(details.get("flowcell", "")).strip()
@@ -977,25 +982,25 @@ class ReadTotalsDataHandler(SafeHandler):
             key=query,
         ).get_result()["rows"]
         if not sample_rows:
-            return None
+            return None, None
 
         total_samples = len(sample_rows[0].get("value") or {})
         if total_samples == 0:
-            return None
-
+            return None, None
+        sequencing_ordered = ReadTotalsDataHandler._parse_units_ordered(
+            details.get("sequence_units_ordered_(lanes)")
+        )
         if flowcell_type.startswith("Universal-"):
-            units_ordered = ReadTotalsDataHandler._parse_units_ordered(
-                details.get("sequence_units_ordered_(lanes)")
-            )
-            if units_ordered is None:
-                return None
+            if sequencing_ordered is None:
+                return None, None
 
             return (
-                units_ordered
+                sequencing_ordered
                 * ReadTotalsDataHandler.UNIT_YIELD
                 * ReadTotalsDataHandler.FLOWCELL_YIELD_FACTOR
                 / total_samples
-                * ReadTotalsDataHandler.SAMPLE_YIELD_FACTOR
+                * ReadTotalsDataHandler.SAMPLE_YIELD_FACTOR,
+                "units",
             )
 
         # Prefer the run mode already loaded with the per-sample flowcell rows.
@@ -1006,7 +1011,7 @@ class ReadTotalsDataHandler(SafeHandler):
                 details.get("flowcell_id") or details.get("flowcell") or ""
             ).strip()
             if not flowcell_name:
-                return None
+                return None, None
 
             flowcell_rows = app.cloudant.post_view(
                 db="x_flowcells",
@@ -1015,7 +1020,7 @@ class ReadTotalsDataHandler(SafeHandler):
                 key=flowcell_name,
             ).get_result()["rows"]
             if not flowcell_rows:
-                return None
+                return None, None
 
             run_mode = str(
                 flowcell_rows[0].get("value", {}).get("run_mode", "")
@@ -1023,14 +1028,16 @@ class ReadTotalsDataHandler(SafeHandler):
 
         lane_threshold = thresholds.get(run_mode, 0)
         if lane_threshold <= 0:
-            return None
+            return None, None
 
         return (
-            lane_threshold
+            sequencing_ordered
+            * lane_threshold
             * 1_000_000
             * ReadTotalsDataHandler.FLOWCELL_YIELD_FACTOR
             / total_samples
-            * ReadTotalsDataHandler.SAMPLE_YIELD_FACTOR
+            * ReadTotalsDataHandler.SAMPLE_YIELD_FACTOR,
+            "lanes",
         )
 
 

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -783,15 +783,15 @@ class FlowcellLinksDataHandler(SafeHandler):
                 self.finish(json.dumps(links))
 
 
-class ReadsTotalHandler(SafeHandler):
+class ReadTotalsHandler(SafeHandler):
     """Serves external links for each project
     Links are stored as JSON in LIMS / project
-    URL: /reads_total/([^/]*)
+    URL: /read_totals/([^/]*)
     """
 
     def get(self, query):
         self.set_header("Content-type", "text/html")
-        t = self.application.loader.load("reads_total.html")
+        t = self.application.loader.load("read_totals.html")
 
         self.write(
             t.generate(
@@ -802,10 +802,10 @@ class ReadsTotalHandler(SafeHandler):
         )
 
 
-class ReadsTotalDataHandler(SafeHandler):
-    """API endpoint for reads_total data
+class ReadTotalsDataHandler(SafeHandler):
+    """API endpoint for read totals data
 
-    Loaded through /api/v1/reads_total/([^/]*)$
+    Loaded through /api/v1/read_totals/([^/]*)$
     Returns JSON with reads data for the given query
     """
 
@@ -916,7 +916,7 @@ class ReadsTotalDataHandler(SafeHandler):
 
         for sample_name, sample_rows in data.items():
             sample_data = project_sample_data.get(sample_name, {})
-            lib_qc_status = ReadsTotalDataHandler._sample_passed_library_qc(sample_data)
+            lib_qc_status = ReadTotalsDataHandler._sample_passed_library_qc(sample_data)
             for sample_row in sample_rows:
                 sample_row["lib_qc"] = lib_qc_status
 
@@ -984,7 +984,7 @@ class ReadsTotalDataHandler(SafeHandler):
             return None
 
         if flowcell_type.startswith("Universal-"):
-            units_ordered = ReadsTotalDataHandler._parse_units_ordered(
+            units_ordered = ReadTotalsDataHandler._parse_units_ordered(
                 details.get("sequence_units_ordered_(lanes)")
             )
             if units_ordered is None:
@@ -992,10 +992,10 @@ class ReadsTotalDataHandler(SafeHandler):
 
             return (
                 units_ordered
-                * ReadsTotalDataHandler.UNIT_YIELD
-                * ReadsTotalDataHandler.FLOWCELL_YIELD_FACTOR
+                * ReadTotalsDataHandler.UNIT_YIELD
+                * ReadTotalsDataHandler.FLOWCELL_YIELD_FACTOR
                 / total_samples
-                * ReadsTotalDataHandler.SAMPLE_YIELD_FACTOR
+                * ReadTotalsDataHandler.SAMPLE_YIELD_FACTOR
             )
 
         # Prefer the run mode already loaded with the per-sample flowcell rows.
@@ -1028,9 +1028,9 @@ class ReadsTotalDataHandler(SafeHandler):
         return (
             lane_threshold
             * 1_000_000
-            * ReadsTotalDataHandler.FLOWCELL_YIELD_FACTOR
+            * ReadTotalsDataHandler.FLOWCELL_YIELD_FACTOR
             / total_samples
-            * ReadsTotalDataHandler.SAMPLE_YIELD_FACTOR
+            * ReadTotalsDataHandler.SAMPLE_YIELD_FACTOR
         )
 
 

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -820,7 +820,7 @@ class ReadsTotalDataHandler(SafeHandler):
         else:
             data = self.get_total_reads(self.application, query)
             expected_min_yield_per_sample = self.get_expected_min_yield_per_sample(
-                self.application, list(data.keys())
+                self.application, query,list(data.keys())
             )
 
         # Check if any data is HiSeq X to mark in response
@@ -939,17 +939,15 @@ class ReadsTotalDataHandler(SafeHandler):
         return None
 
     @staticmethod
-    def get_expected_min_yield_per_sample(app, sample_names):
+    def get_expected_min_yield_per_sample(app, query, sample_names):
         if not sample_names:
             return None
-
-        project_id = sample_names[0].split("_", 1)[0]
 
         project_rows = app.cloudant.post_view(
             db="projects",
             ddoc="project",
             view="project_id",
-            key=project_id,
+            key=query,
             include_docs=True,
         ).get_result()["rows"]
         if not project_rows:
@@ -966,7 +964,7 @@ class ReadsTotalDataHandler(SafeHandler):
             db="projects",
             ddoc="project",
             view="samples",
-            key=project_id,
+            key=query,
         ).get_result()["rows"]
         if not sample_rows:
             return None

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -812,8 +812,12 @@ class ReadsTotalDataHandler(SafeHandler):
     def get(self, query):
         if not query:
             data = {}
+            expected_min_yield_per_sample = None
         else:
             data = self.get_total_reads(self.application, query)
+            expected_min_yield_per_sample = self.get_expected_min_yield_per_sample(
+                self.application, list(data.keys())
+            )
 
         # Check if any data is HiSeq X to mark in response
         is_hiseq_x = False
@@ -824,6 +828,7 @@ class ReadsTotalDataHandler(SafeHandler):
                     break
 
         data["isHiseqX"] = is_hiseq_x
+        data["expectedMinYieldPerSample"] = expected_min_yield_per_sample
 
         self.set_header("Content-type", "application/json")
         self.write(json.dumps(data))
@@ -923,6 +928,62 @@ class ReadsTotalDataHandler(SafeHandler):
             return sample_data["details"]["passed_library_qc"]
 
         return "-"
+
+    @staticmethod
+    def _parse_units_ordered(value):
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        if isinstance(value, str):
+            normalized = value.strip().replace(",", ".")
+            if not normalized:
+                return None
+            try:
+                return float(normalized)
+            except ValueError:
+                return None
+
+        return None
+
+    @staticmethod
+    def get_expected_min_yield_per_sample(app, sample_names):
+        project_ids = {sample.split("_")[0] for sample in sample_names if "_" in sample}
+        if len(project_ids) != 1:
+            return None
+
+        project_id = next(iter(project_ids))
+
+        project_rows = app.cloudant.post_view(
+            db="projects",
+            ddoc="project",
+            view="project_id",
+            key=project_id,
+            include_docs=True,
+        ).get_result()["rows"]
+        if not project_rows:
+            return None
+
+        details = project_rows[0].get("doc", {}).get("details", {})
+        units_ordered = ReadsTotalDataHandler._parse_units_ordered(
+            details.get("sequence_units_ordered_(lanes)")
+        )
+        if units_ordered is None:
+            return None
+
+        sample_rows = app.cloudant.post_view(
+            db="projects",
+            ddoc="project",
+            view="samples",
+            key=project_id,
+        ).get_result()["rows"]
+        if not sample_rows:
+            return None
+
+        total_samples = len(sample_rows[0].get("value") or {})
+        if total_samples == 0:
+            return None
+
+        return units_ordered * 600_000_000 * 0.9 / total_samples * 0.75
 
 
 # Functions

--- a/status/projects.py
+++ b/status/projects.py
@@ -18,7 +18,7 @@ from genologics.entities import Artifact
 from ibm_cloud_sdk_core.api_exception import ApiException
 from zenpy import ZenpyException
 
-from status.flowcells import ReadsTotalDataHandler
+from status.flowcells import ReadTotalsDataHandler
 from status.reports import (
     MultiQCReportHandler,
     ProjectSummaryReportHandler,
@@ -723,7 +723,7 @@ class ProjectReadsSequencedHandler(ProjectsBaseDataHandler):
 
         summary_row = view_rows[0]
         self.set_header("Content-type", "application/json")
-        all_reads = ReadsTotalDataHandler.get_total_reads(self.application, project)
+        all_reads = ReadTotalsDataHandler.get_total_reads(self.application, project)
         reads_sum = 0
         for flowcells in all_reads.values():
             for flowcell in flowcells:

--- a/status_app.py
+++ b/status_app.py
@@ -56,8 +56,8 @@ from status.flowcells import (
     FlowcellsHandler,
     FlowcellsInfoDataHandler,
     OldFlowcellsInfoDataHandler,
-    ReadsTotalDataHandler,
-    ReadsTotalHandler,
+    ReadTotalsDataHandler,
+    ReadTotalsHandler,
 )
 from status.hashtag_csv import HashTagCSVHandler
 from status.instruments import (
@@ -334,7 +334,7 @@ class Application(tornado.web.Application):
             ("/api/v1/presets/onloadcheck", PresetsOnLoadHandler),
             ("/api/v1/qpcr_pools", qPCRPoolsDataHandler),
             ("/api/v1/rna_report/([^/]*$)", ProjectRNAMetaDataHandler),
-            ("/api/v1/reads_total/([^/]*)$", ReadsTotalDataHandler),
+            ("/api/v1/read_totals/([^/]*)$", ReadTotalsDataHandler),
             ("/api/v1/user_management/roles_teams", RolesAndTeamsHandler),
             ("/api/v1/running_notes/([^/]*)$", RunningNotesDataHandler),
             ("/api/v1/links/([^/]*)$", LinksDataHandler),
@@ -439,7 +439,7 @@ class Application(tornado.web.Application):
             ("/project_cards", ProjectCardsHandler),
             ("/proj_meta", ProjMetaCompareHandler),
             ("/proj_summary_report/([^/]*)$", ProjectSummaryReportHandler),
-            ("/reads_total/([^/]*)$", ReadsTotalHandler),
+            ("/read_totals/([^/]*)$", ReadTotalsHandler),
             ("/rec_ctrl_view/([^/]*)$", RecCtrlDataHandler),
             ("/sample_requirements", SampleRequirementsViewHandler),
             ("/sample_requirements_preview", SampleRequirementsPreviewHandler),
@@ -607,7 +607,7 @@ class Application(tornado.web.Application):
             tornado.autoreload.watch("design/project_samples_old.html")
             tornado.autoreload.watch("design/projects.html")
             tornado.autoreload.watch("design/project_cards.html")
-            tornado.autoreload.watch("design/reads_total.html")
+            tornado.autoreload.watch("design/read_totals.html")
             tornado.autoreload.watch("design/rec_ctrl_view.html")
             tornado.autoreload.watch("design/running_notes_help.html")
             tornado.autoreload.watch("design/running_notes_tab.html")


### PR DESCRIPTION
* Merges the tables and makes the new table collapsable 
* Improves features for selecting runs/samples to include/exclude
* Adds a horizontal bar to the plot to visualise the minimum project sample yield threshold
* Adds feature to tick/untick samples that failed library qc
* Retains feature to download the selected data to tsv